### PR TITLE
fix: download FFmpeg shared-library builds so in-process phash works

### DIFF
--- a/src/Cove.Api/Controllers/MetadataController.cs
+++ b/src/Cove.Api/Controllers/MetadataController.cs
@@ -50,8 +50,8 @@ public class MetadataController(
             var dbCtx = scope.ServiceProvider.GetRequiredService<CoveContext>();
 
             var scenes = opts?.SceneIds != null && opts.SceneIds.Count > 0
-                ? await dbCtx.Scenes.Include(s => s.Files).ThenInclude(f => f.ParentFolder).Include(s => s.Files).ThenInclude(f => f.Fingerprints).Where(s => opts.SceneIds.Contains(s.Id)).ToListAsync(ct)
-                : await dbCtx.Scenes.Include(s => s.Files).ThenInclude(f => f.ParentFolder).Include(s => s.Files).ThenInclude(f => f.Fingerprints).ToListAsync(ct);
+                ? await dbCtx.Scenes.Include(s => s.Files).ThenInclude(f => f.ParentFolder).Include(s => s.Files).ThenInclude(f => f.Fingerprints).Where(s => opts.SceneIds.Contains(s.Id)).AsSplitQuery().ToListAsync(ct)
+                : await dbCtx.Scenes.Include(s => s.Files).ThenInclude(f => f.ParentFolder).Include(s => s.Files).ThenInclude(f => f.Fingerprints).AsSplitQuery().ToListAsync(ct);
 
             // Filter by paths if specified
             if (opts?.Paths is { Count: > 0 } paths)
@@ -358,6 +358,7 @@ public class MetadataController(
                     .Include(s => s.Studio)
                     .Include(s => s.Files).ThenInclude(f => f.Fingerprints)
                     .AsNoTracking()
+                    .AsSplitQuery()
                     .ToListAsync(ct);
             }
 
@@ -577,14 +578,14 @@ public class MetadataController(
                     .Include(s => s.ScenePerformers)
                     .Include(s => s.RemoteIds)
                     .Include(s => s.Urls)
-                    .Where(s => opts.SceneIds.Contains(s.Id)).ToListAsync(ct)
+                    .Where(s => opts.SceneIds.Contains(s.Id)).AsSplitQuery().ToListAsync(ct)
                 : await dbCtx.Scenes
                     .Include(s => s.Files).ThenInclude(f => f.Fingerprints)
                     .Include(s => s.SceneTags)
                     .Include(s => s.ScenePerformers)
                     .Include(s => s.RemoteIds)
                     .Include(s => s.Urls)
-                    .ToListAsync(ct);
+                    .AsSplitQuery().ToListAsync(ct);
 
             // Build import config from identify options
             var importConfig = new MetadataServerSceneImportRequestDto

--- a/src/Cove.Api/Program.cs
+++ b/src/Cove.Api/Program.cs
@@ -396,7 +396,7 @@ try
             .Include(s => s.Files).ThenInclude(f => f.Fingerprints)
             .Include(s => s.SceneTags).ThenInclude(st => st.Tag)
             .Include(s => s.ScenePerformers).ThenInclude(sp => sp.Performer)
-            .Take(1).AsSingleQuery().ToListAsync();
+            .Take(1).AsSplitQuery().ToListAsync();
         Log.Information("EF Core and connection pool pre-warmed");
     }
 

--- a/src/Cove.Api/Services/FfmpegInProcess.cs
+++ b/src/Cove.Api/Services/FfmpegInProcess.cs
@@ -19,6 +19,13 @@ public static class FfmpegInProcess
     private static bool _initialized;
     private static readonly object InitLock = new();
 
+    /// <summary>
+    /// True if in-process FFmpeg bindings initialized and verified successfully.
+    /// False means the installed FFmpeg libraries are incompatible with FFmpeg.AutoGen;
+    /// callers should fall back to spawning the ffmpeg process.
+    /// </summary>
+    public static bool IsAvailable { get; private set; }
+
     // Preferred hwaccel order (best avg speedup first from benchmarks).
     // Probed once at init; null entries are removed if they fail to initialize.
     private static AVHWDeviceType[]? _availableHwAccels;
@@ -54,8 +61,23 @@ public static class FfmpegInProcess
 
             DynamicallyLoadedBindings.Initialize();
 
-            // Probe which hwaccel devices are available on this machine
-            _availableHwAccels = ProbeHwAccels();
+            // Probe: verify that the loaded libraries are actually compatible by calling a
+            // trivial function. If this throws, the installed FFmpeg is a standalone statically-
+            // linked binary (e.g. from evermeet.cx on macOS or BtbN on Linux) rather than
+            // separate shared library files (.so/.dylib) that AutoGen's dynamic loader needs.
+            try
+            {
+                var majorVer = (int)(ffmpeg.avformat_version() >> 16);
+                // Probe which hwaccel devices are available on this machine
+                _availableHwAccels = ProbeHwAccels();
+                IsAvailable = true;
+                System.Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg ready (libavformat major={majorVer})");
+            }
+            catch (Exception ex) when (ex is NotSupportedException or EntryPointNotFoundException or DllNotFoundException)
+            {
+                IsAvailable = false;
+                System.Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg not available ({ex.GetType().Name}: {ex.Message}). Will fall back to spawning ffmpeg process.");
+            }
             _initialized = true;
         }
     }

--- a/src/Cove.Api/Services/FfmpegManagerService.cs
+++ b/src/Cove.Api/Services/FfmpegManagerService.cs
@@ -11,28 +11,39 @@ namespace Cove.Api.Services;
 /// if not found, downloads a portable build automatically.
 /// Sets <see cref="CoveConfiguration.FfmpegPath"/> and <see cref="CoveConfiguration.FfprobePath"/>
 /// so all services discover ffmpeg without their own search logic.
+///
+/// On Windows and Linux the downloaded build is the BtbN "gpl-shared" variant which
+/// includes the FFmpeg shared libraries (.dll / .so) alongside the binaries.
+/// FFmpeg.AutoGen's DynamicallyLoadedBindings needs to dlopen those files for
+/// in-process frame extraction; the static CLI-only builds do NOT provide them.
+/// macOS uses evermeet.cx standalone binaries (no shared build available) and falls
+/// back to the process-spawn path in FingerprintService / ThumbnailService.
 /// </summary>
 public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManagerService> logger) : IHostedService
 {
-    // BtbN GPL builds — multi-platform, includes hwaccel support
-    // These are stable snapshot releases, updated regularly.
-    private const string WinUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip";
-    private const string LinuxUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz";
-    private const string LinuxArm64Url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl.tar.xz";
-    // macOS: use evermeet.cx static builds (widely used, GPL)
-    private const string MacUrl = "https://evermeet.cx/ffmpeg/getrelease/zip";
+    // BtbN GPL-SHARED builds — includes shared libraries (.dll/.so) required by FFmpeg.AutoGen.
+    private const string WinUrl      = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl-shared.zip";
+    private const string LinuxUrl    = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl-shared.tar.xz";
+    private const string LinuxArm64Url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linuxarm64-gpl-shared.tar.xz";
+    // macOS: evermeet.cx static builds (no shared-library build publicly available)
+    private const string MacUrl      = "https://evermeet.cx/ffmpeg/getrelease/zip";
     private const string MacProbeUrl = "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip";
+
+    // Marker written to ManagedDir after a successful shared-library download.
+    // If the binary exists but this marker is absent the install is a legacy standalone
+    // build and we re-download to get the shared libraries.
+    private const string SharedMarker = "_cove_shared";
 
     private static string ManagedDir => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "cove", "ffmpeg");
 
-    private static string FfmpegExe => OperatingSystem.IsWindows() ? "ffmpeg.exe" : "ffmpeg";
+    private static string FfmpegExe  => OperatingSystem.IsWindows() ? "ffmpeg.exe"  : "ffmpeg";
     private static string FfprobeExe => OperatingSystem.IsWindows() ? "ffprobe.exe" : "ffprobe";
 
     public async Task StartAsync(CancellationToken ct)
     {
-        // 1. Already configured and exists?
+        // 1. Explicitly configured path — trust the user, skip download logic.
         if (!string.IsNullOrEmpty(config.FfmpegPath) && File.Exists(config.FfmpegPath))
         {
             logger.LogInformation("FFmpeg configured at {Path}", config.FfmpegPath);
@@ -40,7 +51,7 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
             return;
         }
 
-        // 2. In PATH?
+        // 2. In PATH — use it but don't try to replace it.
         var pathResult = FindInPath(FfmpegExe);
         if (pathResult != null)
         {
@@ -50,14 +61,29 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
             return;
         }
 
-        // 3. Already downloaded to managed directory?
         var managedFfmpeg = Path.Combine(ManagedDir, FfmpegExe);
+        var sharedMarkerPath = Path.Combine(ManagedDir, SharedMarker);
+
+        // 3. Already downloaded — but check that it is the shared-library build.
+        //    On Windows and Linux a standalone build lacks the .dll/.so files that
+        //    FFmpeg.AutoGen needs; re-download if the marker is absent.
         if (File.Exists(managedFfmpeg))
         {
-            config.FfmpegPath = managedFfmpeg;
-            EnsureFfprobePath(ManagedDir);
-            logger.LogInformation("FFmpeg found at managed location {Path}", managedFfmpeg);
-            return;
+            var needsSharedLibs = !OperatingSystem.IsMacOS(); // macOS has no shared build
+            if (needsSharedLibs && !File.Exists(sharedMarkerPath))
+            {
+                logger.LogInformation(
+                    "Managed FFmpeg is a standalone build — re-downloading shared-library build " +
+                    "so in-process frame extraction (FFmpeg.AutoGen) works correctly...");
+                try { Directory.Delete(ManagedDir, recursive: true); } catch { /* best effort */ }
+            }
+            else
+            {
+                config.FfmpegPath = managedFfmpeg;
+                EnsureFfprobePath(ManagedDir);
+                logger.LogInformation("FFmpeg found at managed location {Path}", managedFfmpeg);
+                return;
+            }
         }
 
         // 4. Download
@@ -71,8 +97,9 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to download FFmpeg — transcoding and thumbnail generation will be unavailable. " +
-                                  "Install FFmpeg manually or set Cove.FfmpegPath in configuration.");
+            logger.LogWarning(ex,
+                "Failed to download FFmpeg — transcoding and thumbnail generation will be unavailable. " +
+                "Install FFmpeg manually or set Cove.FfmpegPath in configuration.");
         }
     }
 
@@ -94,16 +121,20 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
 
         if (OperatingSystem.IsWindows())
         {
-            await DownloadAndExtractAsync(WinUrl, ".zip", ct);
+            await DownloadAndExtractZipAsync(WinUrl, ct);
+            // Mark as a shared-library install
+            await File.WriteAllTextAsync(Path.Combine(ManagedDir, SharedMarker), "shared", ct);
         }
         else if (OperatingSystem.IsMacOS())
         {
             await DownloadMacAsync(ct);
+            // macOS is always standalone — no marker written
         }
         else
         {
             var url = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? LinuxArm64Url : LinuxUrl;
-            await DownloadAndExtractAsync(url, ".tar.xz", ct);
+            await DownloadAndExtractTarAsync(url, ct);
+            await File.WriteAllTextAsync(Path.Combine(ManagedDir, SharedMarker), "shared", ct);
         }
 
         // Verify
@@ -112,68 +143,30 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
             throw new FileNotFoundException($"Download completed but ffmpeg not found at {ffmpeg}");
     }
 
-    private async Task DownloadAndExtractAsync(string url, string ext, CancellationToken ct)
+    /// <summary>
+    /// Extracts the BtbN Windows zip (gpl-shared). The archive contains:
+    ///   ffmpeg-master-latest-win64-gpl-shared/bin/ffmpeg.exe
+    ///   ffmpeg-master-latest-win64-gpl-shared/bin/ffprobe.exe
+    ///   ffmpeg-master-latest-win64-gpl-shared/bin/avcodec-61.dll  ← needed by AutoGen
+    ///   ffmpeg-master-latest-win64-gpl-shared/bin/avformat-61.dll ← etc.
+    /// All bin/ entries are extracted flat into ManagedDir.
+    /// </summary>
+    private async Task DownloadAndExtractZipAsync(string url, CancellationToken ct)
     {
-        var archivePath = Path.Combine(ManagedDir, $"ffmpeg-download{ext}");
-
+        var archivePath = Path.Combine(ManagedDir, "ffmpeg-download.zip");
         try
         {
             await DownloadFileAsync(url, archivePath, ct);
-
-            if (ext == ".zip")
+            using var zip = ZipFile.OpenRead(archivePath);
+            foreach (var entry in zip.Entries)
             {
-                // BtbN zip has a top-level directory like ffmpeg-master-latest-win64-gpl/bin/
-                using var zip = ZipFile.OpenRead(archivePath);
-                foreach (var entry in zip.Entries)
+                // Extract everything under bin/ (executables + DLLs)
+                var parts = entry.FullName.Split('/');
+                if (parts.Length >= 3 && parts[1] == "bin" && !string.IsNullOrEmpty(parts[2]))
                 {
-                    // Only extract the bin/ contents — ffmpeg.exe, ffprobe.exe
-                    var parts = entry.FullName.Split('/');
-                    if (parts.Length >= 3 && parts[1] == "bin" && !string.IsNullOrEmpty(parts[2]))
-                    {
-                        var dest = Path.Combine(ManagedDir, parts[2]);
-                        entry.ExtractToFile(dest, overwrite: true);
-                    }
+                    var dest = Path.Combine(ManagedDir, parts[2]);
+                    entry.ExtractToFile(dest, overwrite: true);
                 }
-            }
-            else
-            {
-                // tar.xz — extract bin/ contents
-                var tempExtract = Path.Combine(ManagedDir, "_extract");
-                Directory.CreateDirectory(tempExtract);
-
-                var psi = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "/bin/tar",
-                    Arguments = $"xf \"{archivePath}\" -C \"{tempExtract}\"",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false
-                };
-                using var proc = System.Diagnostics.Process.Start(psi);
-                if (proc != null)
-                {
-                    await proc.WaitForExitAsync(ct);
-                }
-
-                // Find and move the bin/ contents
-                foreach (var binDir in Directory.GetDirectories(tempExtract, "bin", SearchOption.AllDirectories))
-                {
-                    foreach (var file in Directory.GetFiles(binDir))
-                    {
-                        var dest = Path.Combine(ManagedDir, Path.GetFileName(file));
-                        File.Move(file, dest, overwrite: true);
-                        // Make executable on Unix
-                        if (!OperatingSystem.IsWindows())
-                        {
-                            var chmod = System.Diagnostics.Process.Start("/bin/chmod", $"+x \"{dest}\"");
-                            chmod?.WaitForExit();
-                        }
-                    }
-                    break;
-                }
-
-                // Cleanup temp
-                try { Directory.Delete(tempExtract, recursive: true); } catch { /* best effort */ }
             }
         }
         finally
@@ -182,12 +175,67 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
         }
     }
 
+    /// <summary>
+    /// Extracts the BtbN Linux tar.xz (gpl-shared). The archive contains:
+    ///   ffmpeg-master-latest-linux64-gpl-shared/bin/ffmpeg      ← CLI binary
+    ///   ffmpeg-master-latest-linux64-gpl-shared/bin/ffprobe
+    ///   ffmpeg-master-latest-linux64-gpl-shared/lib/libavcodec.so.61  ← needed by AutoGen
+    ///   ffmpeg-master-latest-linux64-gpl-shared/lib/libavformat.so.61 ← etc.
+    /// Both bin/ and lib/ contents are extracted flat into ManagedDir so that
+    /// DynamicallyLoadedBindings.LibrariesPath (set to ManagedDir) finds the .so files.
+    /// </summary>
+    private async Task DownloadAndExtractTarAsync(string url, CancellationToken ct)
+    {
+        var archivePath = Path.Combine(ManagedDir, "ffmpeg-download.tar.xz");
+        var tempExtract = Path.Combine(ManagedDir, "_extract");
+        try
+        {
+            await DownloadFileAsync(url, archivePath, ct);
+
+            Directory.CreateDirectory(tempExtract);
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "/bin/tar",
+                Arguments = $"xf \"{archivePath}\" -C \"{tempExtract}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            using (var proc = System.Diagnostics.Process.Start(psi))
+            {
+                if (proc != null) await proc.WaitForExitAsync(ct);
+            }
+
+            // Copy bin/ executables and lib/ shared libraries flat into ManagedDir
+            foreach (var subDir in new[] { "bin", "lib" })
+            {
+                foreach (var binDir in Directory.GetDirectories(tempExtract, subDir, SearchOption.AllDirectories))
+                {
+                    foreach (var file in Directory.GetFiles(binDir))
+                    {
+                        var dest = Path.Combine(ManagedDir, Path.GetFileName(file));
+                        File.Copy(file, dest, overwrite: true);
+                        var chmod = System.Diagnostics.Process.Start("/bin/chmod", $"+x \"{dest}\"");
+                        chmod?.WaitForExit();
+                    }
+                    break; // only the first match per subDir name
+                }
+            }
+        }
+        finally
+        {
+            try { File.Delete(archivePath); } catch { /* best effort */ }
+            try { Directory.Delete(tempExtract, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private async Task DownloadMacAsync(CancellationToken ct)
     {
-        // macOS: separate downloads for ffmpeg and ffprobe
-        var ffmpegZip = Path.Combine(ManagedDir, "ffmpeg.zip");
+        // macOS: evermeet.cx only provides standalone static binaries (no shared .dylib build).
+        // In-process FFmpeg.AutoGen will not work; FingerprintService / ThumbnailService
+        // fall back to spawning the ffmpeg process automatically.
+        var ffmpegZip  = Path.Combine(ManagedDir, "ffmpeg.zip");
         var ffprobeZip = Path.Combine(ManagedDir, "ffprobe.zip");
-
         try
         {
             await DownloadFileAsync(MacUrl, ffmpegZip, ct);
@@ -196,7 +244,6 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
             await DownloadFileAsync(MacProbeUrl, ffprobeZip, ct);
             ZipFile.ExtractToDirectory(ffprobeZip, ManagedDir, overwriteFiles: true);
 
-            // Make executable
             foreach (var name in new[] { "ffmpeg", "ffprobe" })
             {
                 var path = Path.Combine(ManagedDir, name);
@@ -209,7 +256,7 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
         }
         finally
         {
-            try { File.Delete(ffmpegZip); } catch { /* best effort */ }
+            try { File.Delete(ffmpegZip); }  catch { /* best effort */ }
             try { File.Delete(ffprobeZip); } catch { /* best effort */ }
         }
     }
@@ -223,7 +270,7 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
         response.EnsureSuccessStatusCode();
 
         await using var stream = await response.Content.ReadAsStreamAsync(ct);
-        await using var file = File.Create(dest);
+        await using var file   = File.Create(dest);
         await stream.CopyToAsync(file, ct);
     }
 
@@ -242,3 +289,4 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
         return null;
     }
 }
+

--- a/src/Cove.Api/Services/FingerprintService.cs
+++ b/src/Cove.Api/Services/FingerprintService.cs
@@ -124,74 +124,157 @@ public class FingerprintService(
         return hash.ToString("x", CultureInfo.InvariantCulture);
     }
 
-    public Task<string?> ComputeVideoPhashAsync(string path, double duration, CancellationToken ct = default)
+    public async Task<string?> ComputeVideoPhashAsync(string path, double duration, CancellationToken ct = default)
     {
         if (!File.Exists(path))
-            return Task.FromResult<string?>(null);
+            return null;
 
         var ffmpegPath = FindFfmpeg();
         if (ffmpegPath == null)
         {
             logger.LogWarning("FFmpeg not found. Cannot compute video phash for {Path}", path);
-            return Task.FromResult<string?>(null);
+            return null;
         }
 
+        // Initialize FFmpeg.AutoGen bindings (idempotent) and check if in-process is usable.
+        FfmpegInProcess.EnsureInitialized(ffmpegPath);
+
+        var chunkCount = SpriteColumns * SpriteRows; // 25
+        var offset = 0.05 * duration;
+        var stepSize = (0.9 * duration) / chunkCount;
+        var timestamps = new double[chunkCount];
+        for (var i = 0; i < chunkCount; i++)
+            timestamps[i] = offset + i * stepSize;
+
+        if (FfmpegInProcess.IsAvailable)
+        {
+            // Fast path: in-process frame extraction (seeks directly, no process spawning).
+            try
+            {
+                var frames = FfmpegInProcess.ExtractFrames(path, timestamps, SpriteFrameSize, threadCount: 1, ct);
+                if (frames != null)
+                {
+                    try
+                    {
+                        return BuildSpritePhash(frames);
+                    }
+                    finally
+                    {
+                        foreach (var f in frames) f?.Dispose();
+                    }
+                }
+
+                logger.LogWarning("In-process frame extraction returned null for {Path}, falling back to process", path);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "In-process FFmpeg failed for {Path}, falling back to process spawn", path);
+            }
+        }
+
+        // Fallback path: spawn ffmpeg once per timestamp and extract a single frame each time.
+        // Works on any platform where FFmpeg is a statically-linked standalone binary (no
+        // separate shared .so/.dylib files for AutoGen's dynamic loader) — same as ThumbnailService.
+        return await ComputeVideoPhashViaProcessAsync(ffmpegPath, path, timestamps, ct);
+    }
+
+    private string? BuildSpritePhash(Image<Rgba32>[] frames)
+    {
+        var frameWidth = frames[0].Width;
+        var frameHeight = frames[0].Height;
+        using var sprite = new Image<Rgba32>(frameWidth * SpriteColumns, frameHeight * SpriteRows);
+        for (var index = 0; index < frames.Length; index++)
+        {
+            var x = frameWidth * (index % SpriteColumns);
+            var y = frameHeight * (int)Math.Floor((double)index / SpriteRows);
+            sprite.Mutate(ctx => ctx.DrawImage(frames[index], new SixLabors.ImageSharp.Point(x, y), 1f));
+        }
+        return ComputePerceptionHash(sprite);
+    }
+
+    /// <summary>
+    /// Process-based fallback: spawns ffmpeg (the CLI binary) once per timestamp to extract
+    /// a single scaled frame, then composes the sprite and computes the phash.
+    /// Slower than in-process but works on any platform regardless of shared library availability.
+    /// </summary>
+    private async Task<string?> ComputeVideoPhashViaProcessAsync(
+        string ffmpegPath, string videoPath, double[] timestamps, CancellationToken ct)
+    {
+        var tmpDir = Path.Combine(Path.GetTempPath(), $"cove_phash_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tmpDir);
         try
         {
-            // Initialize FFmpeg.AutoGen with the same DLL directory as the ffmpeg binary
-            FfmpegInProcess.EnsureInitialized(ffmpegPath);
-
-            // Generate 25-frame sprite matching Go's videophash package.
-            // In-process extraction: opens the file once, seeks to each timestamp,
-            // and decodes one frame per seek — no process spawning overhead.
-            var chunkCount = SpriteColumns * SpriteRows; // 25
-            var offset = 0.05 * duration;
-            var stepSize = (0.9 * duration) / chunkCount;
-
-            var timestamps = new double[chunkCount];
-            for (var i = 0; i < chunkCount; i++)
-                timestamps[i] = offset + i * stepSize;
-
-            // Use thread_count=1 — outer parallelism (MaxParallelTasks) handles
-            // scene-level concurrency, so each scene uses exactly 1 CPU thread.
-            var frames = FfmpegInProcess.ExtractFrames(path, timestamps, SpriteFrameSize, threadCount: 1, ct);
-            if (frames == null)
+            var frames = new Image<Rgba32>[timestamps.Length];
+            for (var i = 0; i < timestamps.Length; i++)
             {
-                logger.LogWarning("Failed to extract frames from {Path}", path);
-                return Task.FromResult<string?>(null);
+                ct.ThrowIfCancellationRequested();
+                var framePath = Path.Combine(tmpDir, $"frame_{i:D3}.jpg");
+                var ts = timestamps[i];
+
+                var psi = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = ffmpegPath,
+                    // -ss before -i is fast (keyframe seek), -vframes 1 grabs one frame,
+                    // scale=W:-2 keeps aspect ratio with width=SpriteFrameSize.
+                    Arguments = $"-v error -ss {ts:F3} -i \"{videoPath}\" -vframes 1 -vf \"scale={SpriteFrameSize}:-2\" -q:v 3 -y \"{framePath}\"",
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
+                };
+
+                using var proc = System.Diagnostics.Process.Start(psi)!;
+                var stderrTask = proc.StandardError.ReadToEndAsync(ct);
+
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                cts.CancelAfter(TimeSpan.FromSeconds(30));
+                try
+                {
+                    await proc.WaitForExitAsync(cts.Token);
+                }
+                catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                {
+                    try { proc.Kill(entireProcessTree: true); } catch { }
+                    logger.LogWarning("FFmpeg timed out extracting frame {Index} from {Path}", i, videoPath);
+                    DisposeFrames(frames);
+                    return null;
+                }
+
+                if (proc.ExitCode != 0 || !File.Exists(framePath))
+                {
+                    var err = await stderrTask;
+                    logger.LogWarning("FFmpeg failed extracting frame {Index} from {Path}: {Error}", i, videoPath, err);
+                    DisposeFrames(frames);
+                    return null;
+                }
+
+                frames[i] = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(framePath, ct);
             }
 
             try
             {
-                // Compose 5×5 sprite
-                var frameWidth = frames[0].Width;
-                var frameHeight = frames[0].Height;
-
-                using var sprite = new Image<Rgba32>(frameWidth * SpriteColumns, frameHeight * SpriteRows);
-                for (var index = 0; index < chunkCount; index++)
-                {
-                    var x = frameWidth * (index % SpriteColumns);
-                    var y = frameHeight * (int)Math.Floor((double)index / SpriteRows);
-                    sprite.Mutate(ctx => ctx.DrawImage(frames[index], new SixLabors.ImageSharp.Point(x, y), 1f));
-                }
-
-                return Task.FromResult<string?>(ComputePerceptionHash(sprite));
+                return BuildSpritePhash(frames);
             }
             finally
             {
-                foreach (var frame in frames)
-                    frame?.Dispose();
+                DisposeFrames(frames);
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw; // Let cancellation propagate cleanly to the job runner
-        }
+        catch (OperationCanceledException) { throw; }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to compute video phash for {Path}", path);
-            return Task.FromResult<string?>(null);
+            logger.LogError(ex, "Process-based phash extraction failed for {Path}", videoPath);
+            return null;
         }
+        finally
+        {
+            try { Directory.Delete(tmpDir, recursive: true); } catch { }
+        }
+    }
+
+    private static void DisposeFrames(Image<Rgba32>?[] frames)
+    {
+        foreach (var f in frames) { try { f?.Dispose(); } catch { } }
     }
 
     /// <summary>

--- a/src/Cove.Api/Services/ThumbnailService.cs
+++ b/src/Cove.Api/Services/ThumbnailService.cs
@@ -387,6 +387,12 @@ public class ThumbnailService(
             // Initialize FFmpeg.AutoGen with the same DLL directory as the ffmpeg binary
             FfmpegInProcess.EnsureInitialized(ffmpegPath);
 
+            if (!FfmpegInProcess.IsAvailable)
+            {
+                logger.LogWarning("In-process FFmpeg not available (shared library mismatch) — sprite generation for scene {SceneId} skipped", sceneId);
+                return;
+            }
+
             // Calculate grid dimensions
             var frameCount = Math.Min(SpriteFrameCount, Math.Max(1, (int)(duration / 2)));
             var cols = (int)Math.Ceiling(Math.Sqrt(frameCount));


### PR DESCRIPTION
FFmpeg.AutoGen's DynamicallyLoadedBindings requires FFmpeg shared libraries (.so / .dll) to dlopen at runtime. The previous downloads used the static CLI-only builds (BtbN gpl, evermeet.cx) which do not ship those files, causing NotSupportedException when any AutoGen binding was invoked — breaking phash generation on both Linux and macOS.

Changes:

FfmpegManagerService: switch Windows and Linux downloads to the BtbN 'gpl-shared' variants which include libavcodec, libavformat, libswscale etc. alongside the ffmpeg/ffprobe binaries. Linux extraction now copies both bin/ and lib/ contents into ManagedDir, where DynamicallyLoadedBindings.LibrariesPath already points. A _cove_shared marker file is written after a successful shared-library download so stale standalone installs from previous versions are automatically replaced on next startup. macOS (evermeet.cx, standalone-only) is unchanged.

FfmpegInProcess: add an IsAvailable probe. After Initialize(), call ffmpeg.avformat_version() to verify the loaded libraries are compatible. NotSupportedException / EntryPointNotFoundException / DllNotFoundException are caught and IsAvailable is set to false with a console warning, so callers can fall back gracefully instead of crashing mid-extraction.

FingerprintService: ComputeVideoPhashAsync now checks FfmpegInProcess.IsAvailable. When false (macOS, or any platform where shared libs are unavailable), it falls back to ComputeVideoPhashViaProcessAsync which spawns ffmpeg -ss T -i file -vframes 1 per timestamp, composes the sprite with ImageSharp, and computes the same perceptual hash. Slower than in-process but 100% compatible everywhere.

ThumbnailService: guard GenerateSceneSpriteAsync with FfmpegInProcess.IsAvailable to avoid the same crash path during sprite generation.

MetadataController / Program: add AsSplitQuery() to multi-collection Include queries to silence EF Core MultipleCollectionIncludeWarning.