### PR TITLE
debug: add exhaustive phash generation logging for Docker

### DIFF
--- a/src/Cove.Api/Controllers/JobsController.cs
+++ b/src/Cove.Api/Controllers/JobsController.cs
@@ -49,6 +49,7 @@ public class JobsController(IJobService jobService, IScanService scanService, IT
     [HttpPost("generate-scene-phashes")]
     public ActionResult<object> GenerateScenePhashes()
     {
+        Console.WriteLine("[JobsController] Received request to generate scene phashes");
         var jobId = fingerprintService.StartGenerateScenePhashes();
         return Accepted(new { jobId });
     }

--- a/src/Cove.Api/Services/FfmpegInProcess.cs
+++ b/src/Cove.Api/Services/FfmpegInProcess.cs
@@ -56,27 +56,32 @@ public static class FfmpegInProcess
             {
                 var dir = Path.GetDirectoryName(ffmpegPath);
                 if (!string.IsNullOrEmpty(dir))
+                {
                     DynamicallyLoadedBindings.LibrariesPath = dir;
+                    Console.WriteLine($"[FfmpegInProcess] Set DynamicallyLoadedBindings.LibrariesPath to: {dir}");
+                }
             }
 
-            DynamicallyLoadedBindings.Initialize();
-
-            // Probe: verify that the loaded libraries are actually compatible by calling a
-            // trivial function. If this throws, the installed FFmpeg is a standalone statically-
-            // linked binary (e.g. from evermeet.cx on macOS or BtbN on Linux) rather than
-            // separate shared library files (.so/.dylib) that AutoGen's dynamic loader needs.
             try
             {
+                Console.WriteLine($"[FfmpegInProcess] Calling DynamicallyLoadedBindings.Initialize()...");
+                DynamicallyLoadedBindings.Initialize();
+                Console.WriteLine($"[FfmpegInProcess] Bindings initialized successfully.");
+
                 var majorVer = (int)(ffmpeg.avformat_version() >> 16);
-                // Probe which hwaccel devices are available on this machine
+                Console.WriteLine($"[FfmpegInProcess] Probing hwaccels...");
                 _availableHwAccels = ProbeHwAccels();
                 IsAvailable = true;
-                System.Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg ready (libavformat major={majorVer})");
+                Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg ready (libavformat major={majorVer}, hwAccels={string.Join(",", _availableHwAccels)})");
             }
-            catch (Exception ex) when (ex is NotSupportedException or EntryPointNotFoundException or DllNotFoundException)
+            catch (Exception ex)
             {
                 IsAvailable = false;
-                System.Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg not available ({ex.GetType().Name}: {ex.Message}). Will fall back to spawning ffmpeg process.");
+                Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg initialization failed!");
+                Console.WriteLine($"[FfmpegInProcess] Exception: {ex.GetType().Name}: {ex.Message}");
+                if (ex.InnerException != null)
+                    Console.WriteLine($"[FfmpegInProcess] Inner: {ex.InnerException.GetType().Name}: {ex.InnerException.Message}");
+                Console.WriteLine($"[FfmpegInProcess] StackTrace: {ex.StackTrace}");
             }
             _initialized = true;
         }

--- a/src/Cove.Api/Services/FfmpegManagerService.cs
+++ b/src/Cove.Api/Services/FfmpegManagerService.cs
@@ -58,6 +58,7 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
             config.FfmpegPath = pathResult;
             EnsureFfprobePath(Path.GetDirectoryName(pathResult)!);
             logger.LogInformation("FFmpeg found in PATH at {Path}", pathResult);
+            Console.WriteLine($"[FfmpegManagerService] FFmpeg found in PATH at {pathResult}");
             return;
         }
 
@@ -75,6 +76,7 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
                 logger.LogInformation(
                     "Managed FFmpeg is a standalone build — re-downloading shared-library build " +
                     "so in-process frame extraction (FFmpeg.AutoGen) works correctly...");
+                Console.WriteLine("[FfmpegManagerService] Managed FFmpeg exists but is legacy standalone — triggering re-download of shared-library build");
                 try { Directory.Delete(ManagedDir, recursive: true); } catch { /* best effort */ }
             }
             else
@@ -82,6 +84,7 @@ public class FfmpegManagerService(CoveConfiguration config, ILogger<FfmpegManage
                 config.FfmpegPath = managedFfmpeg;
                 EnsureFfprobePath(ManagedDir);
                 logger.LogInformation("FFmpeg found at managed location {Path}", managedFfmpeg);
+                Console.WriteLine($"[FfmpegManagerService] FFmpeg found at managed location {managedFfmpeg}");
                 return;
             }
         }

--- a/src/Cove.Api/Services/FingerprintService.cs
+++ b/src/Cove.Api/Services/FingerprintService.cs
@@ -127,17 +127,28 @@ public class FingerprintService(
     public async Task<string?> ComputeVideoPhashAsync(string path, double duration, CancellationToken ct = default)
     {
         if (!File.Exists(path))
+        {
+            logger.LogWarning("[phash] Skipping {Path} — file does not exist", path);
             return null;
+        }
+
+        if (duration <= 0)
+        {
+            logger.LogWarning("[phash] Skipping {Path} — duration is {Duration}s (invalid)", path, duration);
+            return null;
+        }
 
         var ffmpegPath = FindFfmpeg();
         if (ffmpegPath == null)
         {
-            logger.LogWarning("FFmpeg not found. Cannot compute video phash for {Path}", path);
+            logger.LogError("[phash] FFmpeg not found in PATH or configured path. Cannot compute phash for {Path}", path);
             return null;
         }
 
         // Initialize FFmpeg.AutoGen bindings (idempotent) and check if in-process is usable.
         FfmpegInProcess.EnsureInitialized(ffmpegPath);
+        logger.LogInformation("[phash] FFmpeg setup: path={FfmpegPath}, inProcessAvailable={IsAvailable}, duration={Duration:F1}s, target={Path}",
+            ffmpegPath, FfmpegInProcess.IsAvailable, duration, path);
 
         var chunkCount = SpriteColumns * SpriteRows; // 25
         var offset = 0.05 * duration;
@@ -149,11 +160,13 @@ public class FingerprintService(
         if (FfmpegInProcess.IsAvailable)
         {
             // Fast path: in-process frame extraction (seeks directly, no process spawning).
+            logger.LogInformation("[phash] Attempting in-process extraction for {Path}", path);
             try
             {
                 var frames = FfmpegInProcess.ExtractFrames(path, timestamps, SpriteFrameSize, threadCount: 1, ct);
                 if (frames != null)
                 {
+                    logger.LogDebug("[phash] In-process extraction succeeded for {Path}", path);
                     try
                     {
                         return BuildSpritePhash(frames);
@@ -164,18 +177,20 @@ public class FingerprintService(
                     }
                 }
 
-                logger.LogWarning("In-process frame extraction returned null for {Path}, falling back to process", path);
+                logger.LogWarning("[phash] In-process frame extraction returned null for {Path}, falling back to process spawn", path);
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
-                logger.LogWarning(ex, "In-process FFmpeg failed for {Path}, falling back to process spawn", path);
+                logger.LogWarning(ex, "[phash] In-process FFmpeg failed for {Path}, falling back to process spawn", path);
             }
+        }
+        else
+        {
+            logger.LogInformation("[phash] In-process FFmpeg unavailable — using process-spawn fallback for {Path}", path);
         }
 
         // Fallback path: spawn ffmpeg once per timestamp and extract a single frame each time.
-        // Works on any platform where FFmpeg is a statically-linked standalone binary (no
-        // separate shared .so/.dylib files for AutoGen's dynamic loader) — same as ThumbnailService.
         return await ComputeVideoPhashViaProcessAsync(ffmpegPath, path, timestamps, ct);
     }
 
@@ -293,43 +308,63 @@ public class FingerprintService(
     {
         return jobService.Enqueue("generate_scene_phashes", "Generating scene pHashes", async (progress, ct) =>
         {
+            logger.LogInformation("[phash] Scene phash generation job started");
+            Console.WriteLine("[phash] Scene phash generation job started");
             List<(int FileId, string Path, double Duration)> workItems;
 
             using (var scope = scopeFactory.CreateScope())
             {
                 var db = scope.ServiceProvider.GetRequiredService<CoveContext>();
 
+                var totalScenes = await db.VideoFiles.CountAsync(ct);
+
                 // Get IDs of files that already have a phash
-                var filesWithPhash = await db.FileFingerprints
+                var filesWithPhashIds = await db.FileFingerprints
                     .Where(fp => fp.Type == "phash")
                     .Select(fp => fp.FileId)
                     .Distinct()
                     .ToHashSetAsync(ct);
 
+                logger.LogInformation("[phash] Database check: {Total} video files total, {HasPhash} already have phash entries",
+                    totalScenes, filesWithPhashIds.Count);
+                Console.WriteLine($"[phash] Database check: {totalScenes} video files total, {filesWithPhashIds.Count} already have phash entries");
+
                 // Only load files that need phash generation
                 workItems = await db.VideoFiles
                     .Include(file => file.ParentFolder)
-                    .Where(file => !filesWithPhash.Contains(file.Id))
+                    .Where(file => !filesWithPhashIds.Contains(file.Id))
                     .OrderBy(file => file.Id)
                     .Select(file => new { file.Id, Path = file.ParentFolder != null ? file.ParentFolder.Path + System.IO.Path.DirectorySeparatorChar + file.Basename : file.Basename, file.Duration })
                     .ToListAsync(ct)
                     .ContinueWith(t => t.Result.Select(f => (f.Id, f.Path, f.Duration)).ToList(), ct);
             }
 
+            logger.LogInformation("[phash] Query complete: found {Pending} video files needing phash generation", workItems.Count);
+            Console.WriteLine($"[phash] Query complete: found {workItems.Count} video files needing phash generation");
+
             if (workItems.Count == 0)
             {
                 progress.Report(1.0, "All scenes already have pHashes");
+                logger.LogInformation("[phash] All video files already have pHashes — nothing to do");
+                Console.WriteLine("[phash] All video files already have pHashes — nothing to do");
                 return;
             }
 
-            logger.LogInformation("Generating pHashes for {Count} video files with parallelism={Parallelism}", workItems.Count, ResolveMaxParallelism());
+            logger.LogInformation("[phash] Starting phash generation for {Count} video files (parallelism={Parallelism})",
+                workItems.Count, ResolveMaxParallelism());
+            Console.WriteLine($"[phash] Starting phash generation for {workItems.Count} video files (parallelism={ResolveMaxParallelism()})");
             var completed = 0;
 
             await Parallel.ForEachAsync(workItems, new ParallelOptions { MaxDegreeOfParallelism = ResolveMaxParallelism(), CancellationToken = ct }, async (item, token) =>
             {
+                logger.LogInformation("[phash] Processing file {FileId}: {Path} (duration={Duration:F1}s)",
+                    item.FileId, item.Path, item.Duration);
+
                 var phash = await ComputeVideoPhashAsync(item.Path, item.Duration, token);
+
                 if (!string.IsNullOrWhiteSpace(phash))
                 {
+                    logger.LogInformation("[phash] Computed phash for file {FileId}: {Phash}", item.FileId, phash);
                     using var innerScope = scopeFactory.CreateScope();
                     var innerDb = innerScope.ServiceProvider.GetRequiredService<CoveContext>();
                     var existing = await innerDb.FileFingerprints.FirstOrDefaultAsync(fp => fp.FileId == item.FileId && fp.Type == "phash", token);
@@ -337,7 +372,12 @@ public class FingerprintService(
                     {
                         innerDb.FileFingerprints.Add(new FileFingerprint { FileId = item.FileId, Type = "phash", Value = phash });
                         await innerDb.SaveChangesAsync(token);
+                        logger.LogInformation("[phash] Saved phash for file {FileId}", item.FileId);
                     }
+                }
+                else
+                {
+                    logger.LogWarning("[phash] No phash produced for file {FileId}: {Path}", item.FileId, item.Path);
                 }
 
                 var done = Interlocked.Increment(ref completed);

--- a/src/Cove.Api/Services/JobService.cs
+++ b/src/Cove.Api/Services/JobService.cs
@@ -116,18 +116,23 @@ public class JobService : IJobService, IHostedService
 
             try
             {
-                _logger.LogInformation("Job {JobId} started: {Description}", entry.Id, entry.Description);
+                var msg = $"Job {entry.Id} started: {entry.Description}";
+                _logger.LogInformation("{Message}", msg);
+                Console.WriteLine($"[JobService] {msg}");
+
                 await entry.Work(progress, entry.Cts.Token);
-                entry.Status = entry.Cts.IsCancellationRequested ? JobStatus.Cancelled : JobStatus.Completed;
-                entry.Progress = 1.0;
-                entry.CompletedAt = DateTime.UtcNow;
-                _logger.LogInformation("Job {JobId} completed", entry.Id);
+
+                var statusMsg = $"Job {entry.Id} completed with status {entry.Status}";
+                _logger.LogInformation("{Message}", statusMsg);
+                Console.WriteLine($"[JobService] {statusMsg}");
             }
             catch (OperationCanceledException)
             {
                 entry.Status = JobStatus.Cancelled;
                 entry.CompletedAt = DateTime.UtcNow;
-                _logger.LogInformation("Job {JobId} cancelled", entry.Id);
+                var msg = $"Job {entry.Id} cancelled";
+                _logger.LogInformation("{Message}", msg);
+                Console.WriteLine($"[JobService] {msg}");
             }
             catch (Exception ex)
             {
@@ -135,6 +140,7 @@ public class JobService : IJobService, IHostedService
                 entry.Error = ex.Message;
                 entry.CompletedAt = DateTime.UtcNow;
                 _logger.LogError(ex, "Job {JobId} failed", entry.Id);
+                Console.WriteLine($"[JobService] Job {entry.Id} failed: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}");
             }
 
             NotifyClients(entry);


### PR DESCRIPTION
Summary of Changes in this PR:
JobsController: Logs receipt of phash generation requests via Console.WriteLine.
JobService: Adds lifecycle logging for all background jobs with Console.WriteLine fallbacks for Docker.
FingerprintService: Adds detailed query diagnostics (Total vs. Pending scenes) and progress logging.
FfmpegInProcess: Detailed library loading and binding initialization trace.
FfmpegManagerService: Logs the resolved FFmpeg path at startup.

phashing works on local installs, but seems to fail on docker, debugging