### PR TITLE
Fix: FFmpeg Hardware Acceleration Crash and UI Safety Toggle

### DIFF
--- a/package-mac-app.sh.txt
+++ b/package-mac-app.sh.txt
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Ensure we are in the script's directory
+cd "$(dirname "$0")"
+
+echo "Packaging Cove.Api for macOS..."
+
+PUBLISH_DIR="publish/osx-arm64"
+APP_DIR="${PUBLISH_DIR}/Cove.app"
+CONTENTS_DIR="${APP_DIR}/Contents"
+MACOS_DIR="${CONTENTS_DIR}/MacOS"
+RESOURCES_DIR="${CONTENTS_DIR}/Resources"
+
+# 1. Create the Directory Structure
+mkdir -p "$MACOS_DIR"
+mkdir -p "$RESOURCES_DIR"
+
+# 2. Copy the binary and relevant files (like appsettings.json or wwwroot)
+if [ ! -f "${PUBLISH_DIR}/Cove.Api" ]; then
+    echo "Error: Cove.Api binary not found in ${PUBLISH_DIR}."
+    echo "Did you run 'dotnet publish' first?"
+    exit 1
+fi
+
+echo "Copying binary and configurations..."
+cp "${PUBLISH_DIR}/Cove.Api" "$MACOS_DIR/"
+cp "${PUBLISH_DIR}/appsettings"*.json "$MACOS_DIR/" 2>/dev/null
+
+# 3. Create the Info.plist file
+echo "Generating Info.plist..."
+cat <<EOF > "$CONTENTS_DIR/Info.plist"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>Cove.Api</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.cove.api</string>
+    <key>CFBundleName</key>
+    <string>Cove</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+echo "✅ App packaged successfully at: ${APP_DIR}"

--- a/src/Cove.Api/Services/ConfigService.cs
+++ b/src/Cove.Api/Services/ConfigService.cs
@@ -57,6 +57,7 @@ public class ConfigService
             Port = cfg.Port,
             MaxParallelTasks = cfg.MaxParallelTasks,
             CalculateMd5 = cfg.CalculateMd5,
+            EnableFfmpegHwAccel = cfg.EnableFfmpegHwAccel,
             VideoExtensions = cfg.VideoExtensions,
             ImageExtensions = cfg.ImageExtensions,
             GalleryExtensions = cfg.GalleryExtensions,
@@ -194,6 +195,7 @@ public class ConfigService
         cfg.Port = dto.Port;
         cfg.MaxParallelTasks = dto.MaxParallelTasks;
         cfg.CalculateMd5 = dto.CalculateMd5;
+        cfg.EnableFfmpegHwAccel = dto.EnableFfmpegHwAccel;
 
         if (dto.VideoExtensions.Count > 0)
             cfg.VideoExtensions = dto.VideoExtensions;

--- a/src/Cove.Api/Services/FfmpegInProcess.cs
+++ b/src/Cove.Api/Services/FfmpegInProcess.cs
@@ -44,7 +44,7 @@ public static class FfmpegInProcess
     /// Uses the directory containing the configured ffmpeg binary, or falls back to PATH.
     /// Safe to call multiple times (idempotent).
     /// </summary>
-    public static void EnsureInitialized(string? ffmpegPath)
+    public static void EnsureInitialized(string? ffmpegPath, bool enableHwAccel = false)
     {
         if (_initialized) return;
         lock (InitLock)
@@ -69,10 +69,20 @@ public static class FfmpegInProcess
                 Console.WriteLine($"[FfmpegInProcess] Bindings initialized successfully.");
 
                 var majorVer = (int)(ffmpeg.avformat_version() >> 16);
-                Console.WriteLine($"[FfmpegInProcess] Probing hwaccels...");
-                _availableHwAccels = ProbeHwAccels();
+                
+                if (enableHwAccel)
+                {
+                    Console.WriteLine($"[FfmpegInProcess] Probing hwaccels...");
+                    _availableHwAccels = ProbeHwAccels();
+                    Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg ready (libavformat major={majorVer}, hwAccels={string.Join(",", _availableHwAccels)})");
+                }
+                else
+                {
+                    _availableHwAccels = [];
+                    Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg ready (libavformat major={majorVer}, Hardware Acceleration: Disabled)");
+                }
+                
                 IsAvailable = true;
-                Console.WriteLine($"[FfmpegInProcess] In-process FFmpeg ready (libavformat major={majorVer}, hwAccels={string.Join(",", _availableHwAccels)})");
             }
             catch (Exception ex)
             {

--- a/src/Cove.Api/Services/FingerprintService.cs
+++ b/src/Cove.Api/Services/FingerprintService.cs
@@ -146,7 +146,7 @@ public class FingerprintService(
         }
 
         // Initialize FFmpeg.AutoGen bindings (idempotent) and check if in-process is usable.
-        FfmpegInProcess.EnsureInitialized(ffmpegPath);
+        FfmpegInProcess.EnsureInitialized(ffmpegPath, config.EnableFfmpegHwAccel);
         logger.LogInformation("[phash] FFmpeg setup: path={FfmpegPath}, inProcessAvailable={IsAvailable}, duration={Duration:F1}s, target={Path}",
             ffmpegPath, FfmpegInProcess.IsAvailable, duration, path);
 

--- a/src/Cove.Api/Services/ThumbnailService.cs
+++ b/src/Cove.Api/Services/ThumbnailService.cs
@@ -385,7 +385,7 @@ public class ThumbnailService(
         try
         {
             // Initialize FFmpeg.AutoGen with the same DLL directory as the ffmpeg binary
-            FfmpegInProcess.EnsureInitialized(ffmpegPath);
+            FfmpegInProcess.EnsureInitialized(ffmpegPath, config.EnableFfmpegHwAccel);
 
             if (!FfmpegInProcess.IsAvailable)
             {

--- a/src/Cove.Core/DTOs/DTOs.cs
+++ b/src/Cove.Core/DTOs/DTOs.cs
@@ -207,6 +207,7 @@ public record CoveConfigDto
     public int Port { get; init; } = 9999;
     public int MaxParallelTasks { get; init; } = 1;
     public bool CalculateMd5 { get; init; }
+    public bool EnableFfmpegHwAccel { get; init; }
     public List<string> VideoExtensions { get; init; } = [];
     public List<string> ImageExtensions { get; init; } = [];
     public List<string> GalleryExtensions { get; init; } = [];

--- a/src/Cove.Core/Interfaces/Configuration.cs
+++ b/src/Cove.Core/Interfaces/Configuration.cs
@@ -12,6 +12,7 @@ public class CoveConfiguration
     public int Port { get; set; } = 9999;
     public int MaxParallelTasks { get; set; } = 1;
     public bool CalculateMd5 { get; set; }
+    public bool EnableFfmpegHwAccel { get; set; } // Default false to prevent instability during native probes
     public List<string> VideoExtensions { get; set; } = [".m4v", ".mp4", ".mov", ".wmv", ".avi", ".mpg", ".mpeg", ".rmvb", ".rm", ".flv", ".asf", ".mkv", ".webm", ".f4v"];
     public List<string> ImageExtensions { get; set; } = [".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif"];
     public List<string> GalleryExtensions { get; set; } = [".zip", ".cbz"];

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -594,6 +594,7 @@ export interface CoveConfig {
   port: number;
   maxParallelTasks: number;
   calculateMd5: boolean;
+  enableFfmpegHwAccel: boolean;
   videoExtensions: string[];
   imageExtensions: string[];
   galleryExtensions: string[];

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1206,6 +1206,17 @@ export function SettingsPage() {
                   onChange={(value) => updateDraft((current) => ({ ...current, maxParallelTasks: value ?? current.maxParallelTasks }))}
                 />
               </div>
+              <div className="mt-4">
+                <CheckboxLabel
+                  label="Enable hardware acceleration (FFmpeg in-process)"
+                  checked={draft.enableFfmpegHwAccel}
+                  onChange={(checked) => updateDraft((current) => ({ ...current, enableFfmpegHwAccel: checked }))}
+                />
+                <p className="mt-1 text-xs text-secondary">
+                  If enabled, Cove will attempt to use hardware acceleration for phash and sprite generation.
+                  <span className="text-red-300 font-medium"> Warning:</span> In some Docker environments, this may cause a fatal process crash due to missing native drivers.
+                </p>
+              </div>
             </SectionCard>
 
             <SectionCard title="FFmpeg" description="Paths to FFmpeg and FFprobe binaries. Leave blank to use system PATH.">


### PR DESCRIPTION
Introduces a safety toggle EnableFfmpegHwAccel (default: false) to prevent fatal native assertion crashes in Docker. Skips problematic native hardware acceleration probes when the toggle is off. Exposes the setting in the Settings -> System tab in the UI.