### PR TITLE
Sort tag detail hierarchy by effective name

### DIFF
--- a/src/Cove.Api/Controllers/TagDtoMapping.cs
+++ b/src/Cove.Api/Controllers/TagDtoMapping.cs
@@ -5,6 +5,8 @@ namespace Cove.Api.Controllers;
 
 internal static class TagDtoMapping
 {
+    public static string EffectiveSortName(Tag tag) => tag.SortName ?? tag.Name;
+
     public static TagDto MapTagDto(Tag tag, List<TagProvenanceDto>? provenance = null)
         => new(
             tag.Id,

--- a/src/Cove.Api/Controllers/TagsController.cs
+++ b/src/Cove.Api/Controllers/TagsController.cs
@@ -499,13 +499,13 @@ public class TagsController(ITagRepository tagRepo, Data.CoveContext db, CustomF
             t.ParentRelations
                 .Where(pr => pr.Parent != null)
                 .Select(pr => pr.Parent!)
-                .OrderBy(TagHierarchySortKey)
+                .OrderBy(TagDtoMapping.EffectiveSortName)
                 .Select(parent => MapTagDto(parent))
                 .ToList(),
             t.ChildRelations
                 .Where(cr => cr.Child != null)
                 .Select(cr => cr.Child!)
-                .OrderBy(TagHierarchySortKey)
+                .OrderBy(TagDtoMapping.EffectiveSortName)
                 .Select(child => MapTagDto(child))
                 .ToList(),
             usageCounts.VideoCount,
@@ -533,8 +533,6 @@ public class TagsController(ITagRepository tagRepo, Data.CoveContext db, CustomF
             t.Organized,
             fieldProvenance);
     }
-
-    private static string TagHierarchySortKey(Tag tag) => tag.SortName ?? tag.Name;
 
     private List<TagListDto> MapTagListDtos(IReadOnlyList<Tag> items, IReadOnlyDictionary<int, TagUsageCounts> usageCountsByTagId)
     {

--- a/src/Cove.Api/Controllers/TagsController.cs
+++ b/src/Cove.Api/Controllers/TagsController.cs
@@ -496,8 +496,18 @@ public class TagsController(ITagRepository tagRepo, Data.CoveContext db, CustomF
             t.Description,
             t.Favorite,
             t.Aliases.Select(a => a.Alias).ToList(),
-            t.ParentRelations.Where(pr => pr.Parent != null).Select(pr => MapTagDto(pr.Parent!)).ToList(),
-            t.ChildRelations.Where(cr => cr.Child != null).Select(cr => MapTagDto(cr.Child!)).ToList(),
+            t.ParentRelations
+                .Where(pr => pr.Parent != null)
+                .Select(pr => pr.Parent!)
+                .OrderBy(TagHierarchySortKey)
+                .Select(parent => MapTagDto(parent))
+                .ToList(),
+            t.ChildRelations
+                .Where(cr => cr.Child != null)
+                .Select(cr => cr.Child!)
+                .OrderBy(TagHierarchySortKey)
+                .Select(child => MapTagDto(child))
+                .ToList(),
             usageCounts.VideoCount,
             usageCounts.PerformerCount,
             usageCounts.ImageCount,
@@ -512,17 +522,19 @@ public class TagsController(ITagRepository tagRepo, Data.CoveContext db, CustomF
             t.UpdatedAt.ToString("o"),
             t.ShowAsSegment,
             t.SegmentColorOverride,
-                t.SegmentLaneOverride,
-                t.Color,
-                t.TagGroupId,
-                t.TagGroup?.Name,
-                t.TagGroup?.Color,
-                t.MinOccurrenceSec,
-                t.MinOccurrencePercent,
-                t.RemoteIds.Select(remoteId => new TagRemoteIdDto(remoteId.Endpoint, remoteId.RemoteId)).ToList(),
-                t.Organized,
-                fieldProvenance);
+            t.SegmentLaneOverride,
+            t.Color,
+            t.TagGroupId,
+            t.TagGroup?.Name,
+            t.TagGroup?.Color,
+            t.MinOccurrenceSec,
+            t.MinOccurrencePercent,
+            t.RemoteIds.Select(remoteId => new TagRemoteIdDto(remoteId.Endpoint, remoteId.RemoteId)).ToList(),
+            t.Organized,
+            fieldProvenance);
     }
+
+    private static string TagHierarchySortKey(Tag tag) => tag.SortName ?? tag.Name;
 
     private List<TagListDto> MapTagListDtos(IReadOnlyList<Tag> items, IReadOnlyDictionary<int, TagUsageCounts> usageCountsByTagId)
     {

--- a/src/Cove.Tests/TagsControllerSegmentTests.cs
+++ b/src/Cove.Tests/TagsControllerSegmentTests.cs
@@ -216,6 +216,64 @@ public class TagsControllerSegmentTests
     }
 
     [Fact]
+    public async Task TagDetail_OrdersParentsAndChildrenByEffectiveSortName()
+    {
+        await using var context = CreateContext();
+
+        var parent = new Tag { Name = "Parent" };
+        var zebraChild = new Tag { Name = "Zebra Child" };
+        var appleChild = new Tag { Name = "Apple Child" };
+        var bravoSortChild = new Tag { Name = "Xylophone Child", SortName = "Bravo Child" };
+        var deltaSortChild = new Tag { Name = "Antelope Child", SortName = "Delta Child" };
+
+        var child = new Tag { Name = "Child" };
+        var zebraParent = new Tag { Name = "Zebra Parent" };
+        var appleParent = new Tag { Name = "Apple Parent" };
+        var bravoSortParent = new Tag { Name = "Xylophone Parent", SortName = "Bravo Parent" };
+        var deltaSortParent = new Tag { Name = "Antelope Parent", SortName = "Delta Parent" };
+
+        context.Tags.AddRange(
+            parent,
+            zebraChild,
+            appleChild,
+            bravoSortChild,
+            deltaSortChild,
+            child,
+            zebraParent,
+            appleParent,
+            bravoSortParent,
+            deltaSortParent);
+        await context.SaveChangesAsync();
+
+        context.Set<TagParent>().AddRange(
+            new TagParent { ParentId = parent.Id, ChildId = zebraChild.Id },
+            new TagParent { ParentId = parent.Id, ChildId = appleChild.Id },
+            new TagParent { ParentId = parent.Id, ChildId = bravoSortChild.Id },
+            new TagParent { ParentId = parent.Id, ChildId = deltaSortChild.Id },
+            new TagParent { ParentId = zebraParent.Id, ChildId = child.Id },
+            new TagParent { ParentId = appleParent.Id, ChildId = child.Id },
+            new TagParent { ParentId = bravoSortParent.Id, ChildId = child.Id },
+            new TagParent { ParentId = deltaSortParent.Id, ChildId = child.Id });
+        await context.SaveChangesAsync();
+
+        var controller = new TagsController(null!, context, new CustomFieldService(context), null!);
+
+        var parentDetailResult = await controller.GetById(parent.Id, CancellationToken.None);
+        var parentDetailOk = Assert.IsType<OkObjectResult>(parentDetailResult.Result);
+        var parentDetail = Assert.IsType<TagDetailDto>(parentDetailOk.Value);
+        Assert.Equal(
+            [appleChild.Name, bravoSortChild.Name, deltaSortChild.Name, zebraChild.Name],
+            parentDetail.Children.Select(tag => tag.Name).ToList());
+
+        var childDetailResult = await controller.GetById(child.Id, CancellationToken.None);
+        var childDetailOk = Assert.IsType<OkObjectResult>(childDetailResult.Result);
+        var childDetail = Assert.IsType<TagDetailDto>(childDetailOk.Value);
+        Assert.Equal(
+            [appleParent.Name, bravoSortParent.Name, deltaSortParent.Name, zebraParent.Name],
+            childDetail.Parents.Select(tag => tag.Name).ToList());
+    }
+
+    [Fact]
     public async Task GetSegmentTitles_UsesVideoSegmentTitles()
     {
         await using var context = CreateContext();


### PR DESCRIPTION
## Summary

Sort tag detail parent and child hierarchy entries by their effective display sort key (`SortName` when present, otherwise `Name`), so tag detail responses return a stable alphabetical hierarchy order.

Adds a regression test covering both parent and child ordering with mixed `Name` and `SortName` values.

## Linked issue

Closes #40

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [x] AI was used for this PR.
  - **Model(s):** GPT-5
  - **Where / how:** Implementation assistance, regression test, and PR description drafting.
- [x] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

Ran all existing tests + the new target test for sorting.

Also verified manually in the UI.

## Checklist

- [x] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [x] Builds and existing tests pass.
- [x] I added or updated tests where it makes sense.
- [x] I updated docs where needed.
- [x] This PR is focused and does not bundle unrelated changes.
