### PR TITLE
Seed random front page filters

### DIFF
--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import { createRouteLinkProps } from "../components/cardNavigation";
 import { useEntityEngagementBatch } from "../hooks/useEntityEngagementBatch";
 import { readAuthenticatedUserHomePageContent, updateAuthenticatedUserUiPreferences } from "../utils/userUiPreferences";
 import { getGalleryDisplayTitle } from "../utils/galleryDisplay";
+import { withSeededRandomSort } from "../utils/seededRandomSort";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -248,20 +249,24 @@ function RecommendationRow({ content, onNavigate }: { content: FrontPageContent;
 // ─── Custom Filter Row ──────────────────────────────────────────────────────
 
 function CustomFilterRecommendationRow({ filter, onNavigate }: { filter: CustomFilter; onNavigate: (r: any) => void }) {
+  const findFilter = useMemo(
+    () => withSeededRandomSort({}, { perPage: 25, sort: filter.sortBy, direction: filter.direction }),
+    [filter],
+  );
+
   const fetchFn = useMemo((): (() => Promise<any>) => {
-    const params = { perPage: 25, sort: filter.sortBy, direction: filter.direction };
     switch (filter.mode) {
-      case "videos": return () => videos.find(params);
-      case "performers": return () => performers.find(params);
-      case "studios": return () => studios.find(params);
-      case "tags": return () => tags.find(params);
-      case "galleries": return () => galleries.find(params);
-      case "groups": return () => groups.find(params);
+      case "videos": return () => videos.find(findFilter);
+      case "performers": return () => performers.find(findFilter);
+      case "studios": return () => studios.find(findFilter);
+      case "tags": return () => tags.find(findFilter);
+      case "galleries": return () => galleries.find(findFilter);
+      case "groups": return () => groups.find(findFilter);
     }
-  }, [filter]);
+  }, [filter.mode, findFilter]);
 
   const { data, isLoading } = useQuery<any>({
-    queryKey: ["front-page", filter.mode, filter.sortBy, filter.direction],
+    queryKey: ["front-page", filter.mode, findFilter],
     queryFn: fetchFn,
   });
 
@@ -297,29 +302,32 @@ function SavedFilterRecommendationRow({ savedFilterId, onNavigate }: { savedFilt
   const parsedFilter = useMemo(() => parseJsonObject<FindFilter>(filter?.findFilter) ?? {}, [filter?.findFilter]);
   const parsedObjectFilter = useMemo(() => parseJsonObject<Record<string, unknown>>(filter?.objectFilter), [filter?.objectFilter]);
   const hasObjectFilter = !!parsedObjectFilter && Object.keys(parsedObjectFilter).length > 0;
-
-  const fetchFn = useMemo((): (() => Promise<any>) => {
-    if (!mode) return () => Promise.resolve({ items: [], totalCount: 0 });
-    const findFilter = {
+  const findFilter = useMemo((): FindFilter | undefined => {
+    if (!mode) return undefined;
+    return withSeededRandomSort({}, {
       ...parsedFilter,
       page: 1,
       perPage: 25,
       sort: parsedFilter.sort ?? DEFAULT_SORT_BY_MODE[mode],
       direction: parsedFilter.direction ?? "desc",
-    };
+    });
+  }, [mode, parsedFilter]);
+
+  const fetchFn = useMemo((): (() => Promise<any>) => {
+    if (!mode) return () => Promise.resolve({ items: [], totalCount: 0 });
     const fetchMap: Record<string, () => Promise<any>> = {
       videos: hasObjectFilter ? () => videos.findFiltered({ findFilter, objectFilter: parsedObjectFilter }) : () => videos.find(findFilter),
       performers: hasObjectFilter ? () => performers.findFiltered({ findFilter, objectFilter: parsedObjectFilter }) : () => performers.find(findFilter),
       studios: hasObjectFilter ? () => studios.findFiltered({ findFilter, objectFilter: parsedObjectFilter }) : () => studios.find(findFilter),
-      tags: () => tags.find(findFilter),
+      tags: hasObjectFilter ? () => tags.findFiltered({ findFilter, objectFilter: parsedObjectFilter }) : () => tags.find(findFilter),
       galleries: hasObjectFilter ? () => galleries.findFiltered({ findFilter, objectFilter: parsedObjectFilter }) : () => galleries.find(findFilter),
       groups: hasObjectFilter ? () => groups.findFiltered({ findFilter, objectFilter: parsedObjectFilter }) : () => groups.find(findFilter),
     };
     return fetchMap[mode] ?? (() => Promise.resolve({ items: [], totalCount: 0 }));
-  }, [mode, parsedFilter, parsedObjectFilter, hasObjectFilter]);
+  }, [mode, findFilter, parsedObjectFilter, hasObjectFilter]);
 
   const { data, isLoading } = useQuery<any>({
-    queryKey: ["front-page-saved", savedFilterId, mode, parsedFilter, parsedObjectFilter],
+    queryKey: ["front-page-saved", savedFilterId, mode, findFilter, parsedObjectFilter],
     queryFn: fetchFn,
     enabled: !!mode,
   });
@@ -840,4 +848,3 @@ function FrontPageEditor({
 function getSavedFilterLabel(item: SavedFilterRow, savedFilterById: Map<number, SavedFilter>) {
   return savedFilterById.get(item.savedFilterId)?.name ?? `Saved Filter #${item.savedFilterId}`;
 }
-

--- a/ui/src/test/HomePageRandomSeed.test.tsx
+++ b/ui/src/test/HomePageRandomSeed.test.tsx
@@ -1,0 +1,180 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HomePage } from "../pages/HomePage";
+
+const MAX_RANDOM_SORT_SEED = 2147483647;
+
+const { mockHomePageContent, mocks } = vi.hoisted(() => {
+  const emptyPage = { items: [], totalCount: 0 };
+  return {
+    mockHomePageContent: {
+      value: JSON.stringify([
+        { type: "custom", mode: "videos", sortBy: "random", direction: "asc", header: "Random Videos" },
+      ]),
+    },
+    mocks: {
+      videosFind: vi.fn(async () => emptyPage),
+      videosFindFiltered: vi.fn(async () => emptyPage),
+      performersFind: vi.fn(async () => emptyPage),
+      performersFindFiltered: vi.fn(async () => emptyPage),
+      studiosFind: vi.fn(async () => emptyPage),
+      studiosFindFiltered: vi.fn(async () => emptyPage),
+      tagsFind: vi.fn(async () => emptyPage),
+      tagsFindFiltered: vi.fn(async () => emptyPage),
+      galleriesFind: vi.fn(async () => emptyPage),
+      galleriesFindFiltered: vi.fn(async () => emptyPage),
+      groupsFind: vi.fn(async () => emptyPage),
+      groupsFindFiltered: vi.fn(async () => emptyPage),
+      groupItemsList: vi.fn(async () => []),
+      savedFiltersGet: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../api/client", () => ({
+  videos: {
+    find: mocks.videosFind,
+    findFiltered: mocks.videosFindFiltered,
+    screenshotUrl: (id: number) => `/api/stream/video/${id}/screenshot`,
+  },
+  performers: { find: mocks.performersFind, findFiltered: mocks.performersFindFiltered },
+  studios: { find: mocks.studiosFind, findFiltered: mocks.studiosFindFiltered },
+  tags: { find: mocks.tagsFind, findFiltered: mocks.tagsFindFiltered },
+  galleries: { find: mocks.galleriesFind, findFiltered: mocks.galleriesFindFiltered },
+  groups: {
+    find: mocks.groupsFind,
+    findFiltered: mocks.groupsFindFiltered,
+    items: { list: mocks.groupItemsList },
+  },
+  savedFilters: { get: mocks.savedFiltersGet },
+}));
+
+vi.mock("../hooks/useEntityEngagementBatch", () => ({
+  useEntityEngagementBatch: () => ({ engagementById: new Map() }),
+}));
+
+vi.mock("../utils/userUiPreferences", () => ({
+  readAuthenticatedUserHomePageContent: () => mockHomePageContent.value,
+  updateAuthenticatedUserUiPreferences: vi.fn(),
+}));
+
+function renderHomePage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <HomePage onNavigate={vi.fn()} />
+    </QueryClientProvider>,
+  );
+}
+
+function randomValueForSeed(seed: number) {
+  return (seed + 0.5) / MAX_RANDOM_SORT_SEED;
+}
+
+describe("HomePage random rows", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockHomePageContent.value = JSON.stringify([
+      { type: "custom", mode: "videos", sortBy: "random", direction: "asc", header: "Random Videos" },
+    ]);
+    class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  it("adds a fresh seed to custom random front-page rows", async () => {
+    const expectedSeed = 101;
+    vi.spyOn(Math, "random").mockReturnValue(randomValueForSeed(expectedSeed));
+
+    renderHomePage();
+
+    await waitFor(() => {
+      expect(mocks.videosFind).toHaveBeenCalledWith(expect.objectContaining({
+        perPage: 25,
+        sort: "random",
+        direction: "asc",
+        seed: expectedSeed,
+      }));
+    });
+  });
+
+  it("generates a new custom row seed for each front-page mount", async () => {
+    const firstSeed = 201;
+    const secondSeed = 202;
+    vi.spyOn(Math, "random")
+      .mockReturnValueOnce(randomValueForSeed(firstSeed))
+      .mockReturnValueOnce(randomValueForSeed(secondSeed));
+
+    const first = renderHomePage();
+    await waitFor(() => expect(mocks.videosFind).toHaveBeenCalled());
+    first.unmount();
+
+    renderHomePage();
+    await waitFor(() => expect(mocks.videosFind).toHaveBeenCalledTimes(2));
+
+    expect(mocks.videosFind).toHaveBeenNthCalledWith(1, expect.objectContaining({ seed: firstSeed }));
+    expect(mocks.videosFind).toHaveBeenNthCalledWith(2, expect.objectContaining({ seed: secondSeed }));
+  });
+
+  it("adds a fresh seed to saved random front-page rows", async () => {
+    const expectedSeed = 301;
+    vi.spyOn(Math, "random").mockReturnValue(randomValueForSeed(expectedSeed));
+    mockHomePageContent.value = JSON.stringify([{ type: "saved", savedFilterId: 7 }]);
+    mocks.savedFiltersGet.mockResolvedValue({
+      id: 7,
+      mode: "videos",
+      name: "Saved Random Videos",
+      findFilter: JSON.stringify({ sort: "random", direction: "desc" }),
+    });
+
+    renderHomePage();
+
+    await waitFor(() => {
+      expect(mocks.videosFind).toHaveBeenCalledWith(expect.objectContaining({
+        page: 1,
+        perPage: 25,
+        sort: "random",
+        direction: "desc",
+        seed: expectedSeed,
+      }));
+    });
+  });
+
+  it("keeps object filters when saved random tag rows are loaded", async () => {
+    const expectedSeed = 401;
+    vi.spyOn(Math, "random").mockReturnValue(randomValueForSeed(expectedSeed));
+    mockHomePageContent.value = JSON.stringify([{ type: "saved", savedFilterId: 9 }]);
+    mocks.savedFiltersGet.mockResolvedValue({
+      id: 9,
+      mode: "tags",
+      name: "Saved Random Tags",
+      findFilter: JSON.stringify({ sort: "random", direction: "asc" }),
+      objectFilter: JSON.stringify({ aliasesCriterion: { modifier: "includes", value: "sample" } }),
+    });
+
+    renderHomePage();
+
+    await waitFor(() => {
+      expect(mocks.tagsFindFiltered).toHaveBeenCalledWith({
+        findFilter: expect.objectContaining({
+          page: 1,
+          perPage: 25,
+          sort: "random",
+          direction: "asc",
+          seed: expectedSeed,
+        }),
+        objectFilter: { aliasesCriterion: { modifier: "includes", value: "sample" } },
+      });
+    });
+    expect(mocks.tagsFind).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Each visit to home page uses a fresh seed for randomized sorting. Previously saved filters with randomized order never changed the seed.

## Linked issue

Closes #34 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.5
  - **Where / how:** Planning, implementing, testing, reviewing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

All existing tests pass. New automated tests added.

Manual testing was run as well.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
