### PR TITLE
Stabilize autocomplete dropdowns

### DIFF
--- a/ui/src/components/AutocompleteDropdown.tsx
+++ b/ui/src/components/AutocompleteDropdown.tsx
@@ -1,0 +1,80 @@
+import { useLayoutEffect, useState, type ReactNode, type RefObject } from "react";
+import { createPortal } from "react-dom";
+
+interface Props {
+  anchorRef: RefObject<HTMLElement | null>;
+  children: ReactNode;
+  className?: string;
+  maxHeight?: number;
+}
+
+interface Position {
+  left: number;
+  top: number;
+  width: number;
+  maxHeight: number;
+  placement: "above" | "below";
+}
+
+export function AutocompleteDropdown({ anchorRef, children, className, maxHeight = 160 }: Props) {
+  const [position, setPosition] = useState<Position | null>(null);
+
+  useLayoutEffect(() => {
+    const place = () => {
+      const anchor = anchorRef.current;
+      if (!anchor) return;
+
+      const rect = anchor.getBoundingClientRect();
+      const viewport = window.visualViewport;
+      const visualTop = viewport?.pageTop ?? window.scrollY;
+      const viewportHeight = viewport?.height ?? window.innerHeight;
+      const anchorLeft = rect.left + window.scrollX;
+      const anchorTop = rect.top + window.scrollY;
+      const anchorBottom = rect.bottom + window.scrollY;
+      const gap = 4;
+      const spaceBelow = visualTop + viewportHeight - anchorBottom - gap;
+      const spaceAbove = anchorTop - visualTop - gap;
+      const openAbove = spaceBelow < maxHeight && spaceAbove > spaceBelow;
+      const availableHeight = Math.min(maxHeight, Math.max(0, openAbove ? spaceAbove : spaceBelow));
+
+      setPosition({
+        left: anchorLeft,
+        top: openAbove ? anchorTop - gap : anchorBottom + gap,
+        width: rect.width,
+        maxHeight: availableHeight,
+        placement: openAbove ? "above" : "below",
+      });
+    };
+
+    place();
+    const viewport = window.visualViewport;
+    window.addEventListener("resize", place);
+    window.addEventListener("scroll", place, true);
+    viewport?.addEventListener("resize", place);
+    viewport?.addEventListener("scroll", place);
+    return () => {
+      window.removeEventListener("resize", place);
+      window.removeEventListener("scroll", place, true);
+      viewport?.removeEventListener("resize", place);
+      viewport?.removeEventListener("scroll", place);
+    };
+  }, [anchorRef, maxHeight]);
+
+  if (typeof document === "undefined" || !position) return null;
+
+  return createPortal(
+    <div
+      className={`absolute z-[200] overflow-x-hidden overflow-y-auto shadow-lg ${className ?? ""}`}
+      style={{
+        left: position.left,
+        top: position.top,
+        width: position.width,
+        maxHeight: position.maxHeight,
+        transform: position.placement === "above" ? "translateY(-100%)" : undefined,
+      }}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/ui/src/components/BulkEditDialog.tsx
+++ b/ui/src/components/BulkEditDialog.tsx
@@ -320,7 +320,8 @@ function MultiIdBulkEditor({
         onChange={onValueChange as (values: number[]) => void}
         placeholder={`Search ${entityType}...`}
         inputClassName="w-full bg-input border border-border rounded px-2 py-1 text-xs text-foreground focus:outline-none focus:border-accent placeholder:text-muted"
-        resultsClassName="max-h-32 overflow-y-auto border border-border rounded bg-input"
+        resultsClassName="rounded border border-border bg-input"
+        resultsMaxHeight={128}
       />
     </div>
   );
@@ -475,4 +476,3 @@ export const GROUP_BULK_FIELDS: BulkEditField[] = [
   { key: "description", label: "Description", type: "string" },
   { key: "tagIds", label: "Tags", type: "multiId", entityType: "tags", modeKey: "tagMode" },
 ];
-

--- a/ui/src/components/EntityMultiSelector.tsx
+++ b/ui/src/components/EntityMultiSelector.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useQueries, useQuery } from "@tanstack/react-query";
 import { Plus, X } from "lucide-react";
 import { faces as facesApi, performers as performersApi, tags as tagsApi } from "../api/client";
 import type { Face, Performer, Tag } from "../api/types";
 import { rankSearchOptions } from "../utils/searchRanking";
+import { AutocompleteDropdown } from "./AutocompleteDropdown";
 
 type EntitySelectorType = "tags" | "performers" | "faces";
 
@@ -29,6 +30,7 @@ export function EntityMultiSelector({
   emptyMessage,
 }: EntityMultiSelectorProps) {
   const [searchText, setSearchText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const trimmedSearch = searchText.trim();
 
   const { data: searchResults, isLoading } = useQuery({
@@ -36,6 +38,7 @@ export function EntityMultiSelector({
     queryFn: () => searchEntities(entityType, trimmedSearch),
     enabled: trimmedSearch.length >= 1,
     staleTime: 60_000,
+    placeholderData: (previousData) => previousData,
   });
 
   const searchOptions = useMemo(
@@ -80,7 +83,7 @@ export function EntityMultiSelector({
   );
 
   return (
-    <div className="space-y-2">
+    <div className="relative flex flex-col gap-2">
       {selectedOptions.length > 0 ? (
         <div className="flex flex-wrap gap-1">
           {selectedOptions.map((option) => (
@@ -101,6 +104,7 @@ export function EntityMultiSelector({
       ) : null}
 
       <input
+        ref={inputRef}
         type="text"
         value={searchText}
         onChange={(event) => setSearchText(event.target.value)}
@@ -109,7 +113,7 @@ export function EntityMultiSelector({
       />
 
       {trimmedSearch ? (
-        <div className="max-h-40 overflow-y-auto rounded border border-border bg-surface">
+        <AutocompleteDropdown anchorRef={inputRef} className="rounded border border-border bg-surface">
           {isLoading ? <div className="px-3 py-2 text-sm text-muted">Loading...</div> : null}
           {!isLoading && visibleResults.length === 0 ? (
             <div className="px-3 py-2 text-sm text-muted">{emptyMessage ?? `No ${entityType} found`}</div>
@@ -131,7 +135,7 @@ export function EntityMultiSelector({
               {option.secondaryLabel ? <span className="text-xs text-muted">{option.secondaryLabel}</span> : null}
             </button>
           ))}
-        </div>
+        </AutocompleteDropdown>
       ) : null}
     </div>
   );

--- a/ui/src/components/EntityReferenceSelector.tsx
+++ b/ui/src/components/EntityReferenceSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, X } from "lucide-react";
 import { faces, galleries, groups, images, performers, videos, studios, tags } from "../api/client";
@@ -6,6 +6,7 @@ import type { CustomFieldType, Face, Gallery, Group, Image, Performer, Video, St
 import { TagProvenanceHover } from "./TagProvenanceHover";
 import { TagActionMenu } from "./shared";
 import { rankSearchOptions } from "../utils/searchRanking";
+import { AutocompleteDropdown } from "./AutocompleteDropdown";
 
 export type EntityReferenceType = Extract<CustomFieldType, "tag" | "performer" | "studio" | "video" | "gallery" | "image" | "group"> | "face";
 
@@ -90,6 +91,7 @@ export function EntityReferenceSelector({
   selectedLabel?: string;
 }) {
   const [searchText, setSearchText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const trimmedSearch = searchText.trim();
   const labels = getEntityReferenceLabel(entityType);
   const queryClient = useQueryClient();
@@ -105,11 +107,12 @@ export function EntityReferenceSelector({
     return rankSearchOptions(cachedOptions.filter((option) => option.label.toLowerCase().includes(needle)), trimmedSearch).slice(0, 25);
   }, [cachedOptions, trimmedSearch]);
 
-  const { data: searchResults, isLoading } = useQuery({
+  const { data: searchResults, isLoading, isFetching } = useQuery({
     queryKey: ["entity-reference-selector", entityType, trimmedSearch],
     queryFn: () => searchEntityReferences(entityType, trimmedSearch),
     enabled: !disabled && trimmedSearch.length >= 1 && cachedSearchOptions == null,
     staleTime: 60_000,
+    placeholderData: (previousData) => previousData,
   });
 
   const searchOptions = useMemo(
@@ -157,10 +160,10 @@ export function EntityReferenceSelector({
     },
   });
 
-  const showCreateOption = trimmedSearch && !isLoading && creatableTypes[entityType] && !exactMatchExists;
+  const showCreateOption = trimmedSearch && !isFetching && creatableTypes[entityType] && !exactMatchExists;
 
   return (
-    <div className="min-w-0 space-y-2">
+    <div className="relative flex min-w-0 flex-col gap-2">
       {typeof value === "number" && selectedDisplay === "chip" ? (
         <div className="flex flex-wrap gap-1">
           <span className="inline-flex max-w-full items-center gap-1 rounded border border-border bg-card px-2 py-0.5 text-[10px] text-foreground">
@@ -181,6 +184,7 @@ export function EntityReferenceSelector({
 
       <div className="relative">
         <input
+          ref={inputRef}
           type="text"
           value={showSelectedInInput ? selectedInputLabel : searchText}
           onChange={(event) => setSearchText(event.target.value)}
@@ -210,7 +214,7 @@ export function EntityReferenceSelector({
       </div>
 
       {trimmedSearch ? (
-        <div className="max-h-40 overflow-y-auto overflow-x-hidden rounded border border-border bg-surface">
+        <AutocompleteDropdown anchorRef={inputRef} className="rounded border border-border bg-surface">
           {isLoading ? <div className="px-3 py-2 text-sm text-muted">Loading...</div> : null}
           {!isLoading && visibleResults.length === 0 && !showCreateOption ? (
             <div className="px-3 py-2 text-sm text-muted">No {labels.plural} found</div>
@@ -249,7 +253,7 @@ export function EntityReferenceSelector({
               )}
             </button>
           ) : null}
-        </div>
+        </AutocompleteDropdown>
       ) : null}
     </div>
   );
@@ -264,6 +268,7 @@ export function EntityReferenceMultiSelector({
   disabled = false,
   inputClassName,
   resultsClassName,
+  resultsMaxHeight,
   containerClassName,
   excludeIds,
   lockedIds,
@@ -280,6 +285,7 @@ export function EntityReferenceMultiSelector({
   disabled?: boolean;
   inputClassName?: string;
   resultsClassName?: string;
+  resultsMaxHeight?: number;
   containerClassName?: string;
   excludeIds?: Iterable<number>;
   lockedIds?: Iterable<number>;
@@ -290,6 +296,7 @@ export function EntityReferenceMultiSelector({
   onAdjustThreshold?: (id: number) => void;
 }) {
   const [searchText, setSearchText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const trimmedSearch = searchText.trim();
   const labels = getEntityReferenceLabel(entityType);
   const queryClient = useQueryClient();
@@ -305,11 +312,12 @@ export function EntityReferenceMultiSelector({
     return rankSearchOptions(cachedOptions.filter((option) => option.label.toLowerCase().includes(needle)), trimmedSearch).slice(0, 25);
   }, [cachedOptions, trimmedSearch]);
 
-  const { data: searchResults, isLoading } = useQuery({
+  const { data: searchResults, isLoading, isFetching } = useQuery({
     queryKey: ["entity-reference-selector", entityType, trimmedSearch],
     queryFn: () => searchEntityReferences(entityType, trimmedSearch),
     enabled: !disabled && trimmedSearch.length >= 1 && cachedSearchOptions == null,
     staleTime: 60_000,
+    placeholderData: (previousData) => previousData,
   });
 
   const searchOptions = useMemo(
@@ -349,10 +357,10 @@ export function EntityReferenceMultiSelector({
     },
   });
 
-  const showCreateOption = trimmedSearch && !isLoading && creatableTypes[entityType] && !exactMatchExists;
+  const showCreateOption = trimmedSearch && !isFetching && creatableTypes[entityType] && !exactMatchExists;
 
   return (
-    <div className={containerClassName ?? "space-y-2"}>
+    <div className={`relative ${containerClassName ?? "flex flex-col gap-2"}`}>
       {values.length > 0 ? (
         <div className="flex flex-wrap gap-1">
           {values.map((id) => {
@@ -390,6 +398,7 @@ export function EntityReferenceMultiSelector({
       ) : null}
 
       <input
+        ref={inputRef}
         type="text"
         value={searchText}
         onChange={(event) => setSearchText(event.target.value)}
@@ -399,7 +408,7 @@ export function EntityReferenceMultiSelector({
       />
 
       {trimmedSearch ? (
-        <div className={resultsClassName ?? "max-h-40 overflow-y-auto rounded border border-border bg-surface"}>
+        <AutocompleteDropdown anchorRef={inputRef} maxHeight={resultsMaxHeight} className={resultsClassName ?? "rounded border border-border bg-surface"}>
           {isLoading ? <div className="px-3 py-2 text-sm text-muted">Loading...</div> : null}
           {!isLoading && visibleResults.length === 0 && !showCreateOption ? (
             <div className="px-3 py-2 text-sm text-muted">{emptyMessage ?? `No ${labels.plural} found`}</div>
@@ -438,7 +447,7 @@ export function EntityReferenceMultiSelector({
               )}
             </button>
           ) : null}
-        </div>
+        </AutocompleteDropdown>
       ) : null}
     </div>
   );

--- a/ui/src/components/StudioSelector.tsx
+++ b/ui/src/components/StudioSelector.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, X } from "lucide-react";
 import { studios as studiosApi } from "../api/client";
 import { rankByLabel } from "../utils/searchRanking";
+import { AutocompleteDropdown } from "./AutocompleteDropdown";
 
 interface StudioSelectorProps {
   value?: number;
@@ -12,10 +13,11 @@ interface StudioSelectorProps {
 
 export function StudioSelector({ value, onChange, placeholder = "Search studios..." }: StudioSelectorProps) {
   const [searchText, setSearchText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const trimmedSearch = searchText.trim();
   const queryClient = useQueryClient();
 
-  const { data: searchResults, isLoading } = useQuery({
+  const { data: searchResults, isLoading, isFetching } = useQuery({
     queryKey: ["studio-selector", trimmedSearch],
     queryFn: async () => {
       const response = await studiosApi.find({
@@ -29,6 +31,7 @@ export function StudioSelector({ value, onChange, placeholder = "Search studios.
     },
     staleTime: 60000,
     enabled: trimmedSearch.length >= 1,
+    placeholderData: (previousData) => previousData,
   });
 
   const selectedResult = searchResults?.find((studio) => studio.id === value);
@@ -55,10 +58,10 @@ export function StudioSelector({ value, onChange, placeholder = "Search studios.
       queryClient.invalidateQueries({ queryKey: ["studios"] });
     },
   });
-  const showCreateOption = trimmedSearch && !isLoading && !exactMatchExists;
+  const showCreateOption = trimmedSearch && !isFetching && !exactMatchExists;
 
   return (
-    <div className="space-y-2">
+    <div className="relative flex flex-col gap-2">
       {selectedLabel && (
         <div className="flex flex-wrap gap-1">
           <span className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-0.5 text-[10px] text-foreground">
@@ -71,6 +74,7 @@ export function StudioSelector({ value, onChange, placeholder = "Search studios.
       )}
 
       <input
+        ref={inputRef}
         type="text"
         value={searchText}
         onChange={(e) => setSearchText(e.target.value)}
@@ -79,7 +83,7 @@ export function StudioSelector({ value, onChange, placeholder = "Search studios.
       />
 
       {trimmedSearch && (
-        <div className="max-h-32 overflow-y-auto rounded border border-border bg-surface">
+        <AutocompleteDropdown anchorRef={inputRef} maxHeight={128} className="rounded border border-border bg-surface">
           {isLoading ? (
             <div className="px-3 py-2 text-sm text-muted">Loading...</div>
           ) : visibleResults.length === 0 && !showCreateOption ? (
@@ -115,7 +119,7 @@ export function StudioSelector({ value, onChange, placeholder = "Search studios.
               )}
             </button>
           ) : null}
-        </div>
+        </AutocompleteDropdown>
       )}
     </div>
   );

--- a/ui/src/pages/GalleryDetailPage.tsx
+++ b/ui/src/pages/GalleryDetailPage.tsx
@@ -620,7 +620,8 @@ function AddImagesDialog({ existingImageIds, onAdd, onClose, isPending }: {
             disabled={isPending}
             placeholder="Search images..."
             emptyMessage="No images found"
-            resultsClassName="max-h-72 overflow-y-auto rounded border border-border bg-surface"
+            resultsClassName="rounded border border-border bg-surface"
+            resultsMaxHeight={288}
           />
         </div>
 
@@ -718,4 +719,3 @@ function GalleryFileInfo({ gallery }: { gallery: { folderPath?: string; files: {
     </div>
   );
 }
-

--- a/ui/src/test/EntityReferenceSelector.test.tsx
+++ b/ui/src/test/EntityReferenceSelector.test.tsx
@@ -1,8 +1,27 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { EntityReferenceMultiSelector } from "../components/EntityReferenceSelector";
+
+const mocks = vi.hoisted(() => ({ tagsFind: vi.fn() }));
+
+vi.mock("../api/client", () => ({
+  faces: {},
+  galleries: {},
+  groups: {},
+  images: {},
+  performers: {},
+  studios: {},
+  tags: { find: mocks.tagsFind },
+  videos: {},
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("EntityReferenceMultiSelector", () => {
   it("does not render a remove button for locked tag chips", async () => {
@@ -24,5 +43,46 @@ describe("EntityReferenceMultiSelector", () => {
     expect(await screen.findByText("Derived")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove Manual" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Derived/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps the dropdown results mounted while the next search is loading", async () => {
+    const user = userEvent.setup();
+    let resolveNextSearch!: (value: { items: Array<{ id: number; name: string }> }) => void;
+    const nextSearch = new Promise<{ items: Array<{ id: number; name: string }> }>((resolve) => {
+      resolveNextSearch = resolve;
+    });
+    mocks.tagsFind
+      .mockResolvedValueOnce({ items: [{ id: 1, name: "Massage" }] })
+      .mockReturnValueOnce(nextSearch);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    const input = screen.getByPlaceholderText("Search tags...");
+    vi.spyOn(input, "getBoundingClientRect").mockReturnValue({
+      x: 20, y: 100, left: 20, top: 100, right: 220, bottom: 140,
+      width: 200, height: 40, toJSON: () => ({}),
+    });
+    vi.stubGlobal("scrollY", 480);
+    vi.stubGlobal("visualViewport", { pageLeft: 0, pageTop: 500, height: 300, addEventListener: vi.fn(), removeEventListener: vi.fn() });
+    await user.type(input, "m");
+    const firstResult = await screen.findByRole("button", { name: /Massage/i });
+    const dropdown = firstResult.parentElement;
+    expect(dropdown).toHaveClass("absolute", "z-[200]", "overflow-y-auto", "overflow-x-hidden");
+    expect(dropdown?.parentElement).toBe(document.body);
+    expect(dropdown).toHaveStyle({ left: "20px", top: "624px", width: "200px" });
+
+    await user.type(input, "a");
+    await waitFor(() => expect(mocks.tagsFind).toHaveBeenCalledTimes(2));
+    expect(screen.getByRole("button", { name: /Massage/i })).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create “ma”" })).not.toBeInTheDocument();
+
+    resolveNextSearch({ items: [{ id: 2, name: "Makeup" }] });
+    expect(await screen.findByRole("button", { name: /Makeup/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Previously autocomplete dropdown kept disappearing and reappearing on every keystroke. As dropdown was also placed underneath the input control, it kept bubbling away all the elements below it causing the whole UI to feel constantly in motion.

This PR introduces a floating autocomplete dropdown which stays in place.

## Linked issue

Closes #44 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Implementing, testing, reviewing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

All existing tests pass. A new automated test was added.

I verified this also manually both on desktop browser and on my iPhone in multiple views.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
