### PR TITLE
Fix default image card fit

### DIFF
--- a/src/Cove.Core/DTOs/DTOs.cs
+++ b/src/Cove.Core/DTOs/DTOs.cs
@@ -1400,7 +1400,7 @@ public record UiConfigDto
     public bool WallShowTitle { get; init; } = true;
     public int WallPlayback { get; init; } = 1;
     public string WallPreviewType { get; init; } = "video";
-    public string ImageObjectFit { get; init; } = "cover";
+    public string ImageObjectFit { get; init; } = "contain";
     public string VideoObjectFit { get; init; } = "cover";
     public string FeedVideoSource { get; init; } = "preview";
     public bool FeedVideoSound { get; init; }

--- a/src/Cove.Core/Interfaces/Configuration.cs
+++ b/src/Cove.Core/Interfaces/Configuration.cs
@@ -229,7 +229,7 @@ public class UiConfig
     public bool WallShowTitle { get; set; } = true;
     public int WallPlayback { get; set; } = 1; // 0=Audio, 1=Silent
     public string WallPreviewType { get; set; } = "video";
-    public string ImageObjectFit { get; set; } = "cover";
+    public string ImageObjectFit { get; set; } = "contain";
     public string VideoObjectFit { get; set; } = "cover";
     public string FeedVideoSource { get; set; } = "preview";
     public bool FeedVideoSound { get; set; }

--- a/src/Cove.Tests/ConfigurationDefaultsTests.cs
+++ b/src/Cove.Tests/ConfigurationDefaultsTests.cs
@@ -1,0 +1,19 @@
+using Cove.Core.DTOs;
+using Cove.Core.Interfaces;
+
+namespace Cove.Tests;
+
+public class ConfigurationDefaultsTests
+{
+    [Fact]
+    public void ImageCardFitDefaultsToContainWhileVideoPreviewFitRemainsCover()
+    {
+        var configuration = new CoveConfiguration();
+        var dto = new UiConfigDto();
+
+        Assert.Equal("contain", configuration.Ui.ImageObjectFit);
+        Assert.Equal("cover", configuration.Ui.VideoObjectFit);
+        Assert.Equal("contain", dto.ImageObjectFit);
+        Assert.Equal("cover", dto.VideoObjectFit);
+    }
+}


### PR DESCRIPTION
## Summary

Previous default image card fit caused gallery posters and images to have top and bottom to get cut off. While it was possible to change it from `cover` to `contain`, I think more sensible default is to use `contain`.

## Linked issue

Closes #52 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Implementing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

Tested this manually by creating a new instance and seeing the new default.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
