### PR TITLE
Improve similar faces pagination, fix missing thumbnails

### DIFF
--- a/src/Cove.Api/Controllers/FacesController.cs
+++ b/src/Cove.Api/Controllers/FacesController.cs
@@ -1131,8 +1131,7 @@ public class FacesController(
     {
         page = Math.Max(page, 1);
         perPage = Math.Clamp(perPage, 1, 250);
-        k = Math.Clamp(k, 1, 250);
-        var candidateCount = Math.Clamp(Math.Max(k, page * perPage * 4), 1, 250);
+        var candidateCount = Math.Clamp(k, 1, 250);
 
         var sourceEmbedding = await db.Embeddings
             .AsNoTracking()

--- a/src/Cove.Api/Controllers/FacesController.cs
+++ b/src/Cove.Api/Controllers/FacesController.cs
@@ -1205,6 +1205,14 @@ public class FacesController(
             .Skip((page - 1) * perPage)
             .Take(perPage)
             .ToList();
+        var coverFallbacks = await LoadFaceCoverFallbackUrlsAsync(
+            pageItems.Select(item => faces[item.Id]).ToArray(),
+            cancellationToken);
+        pageItems = pageItems
+            .Select(item => item.CoverImageUrl is null
+                ? item with { CoverImageUrl = coverFallbacks.GetValueOrDefault(item.Id) }
+                : item)
+            .ToList();
 
         return Ok(new PaginatedResponse<FaceSimilarDto>(pageItems, totalCount, page, perPage));
     }

--- a/src/Cove.Tests/AiCoreControllerTests.cs
+++ b/src/Cove.Tests/AiCoreControllerTests.cs
@@ -128,6 +128,68 @@ public class AiCoreControllerTests
     }
 
     [Fact]
+    public async Task FacesController_GetSimilar_HonorsExactCandidateLimitAcrossPages()
+    {
+        await using var scope = await CreateContextAsync();
+        var context = scope.Context;
+        var sourceFace = new Face { Label = "Source", PrimarySourceKey = "ext:ai.faces" };
+        context.Faces.Add(sourceFace);
+        await context.SaveChangesAsync();
+
+        var candidateFaces = Enumerable.Range(1, 8)
+            .Select(index => new Face { Label = $"Candidate {index}", PrimarySourceKey = $"candidate:{index}" })
+            .ToArray();
+        context.Faces.AddRange(candidateFaces);
+        await context.SaveChangesAsync();
+
+        context.Embeddings.Add(new Embedding
+        {
+            HostType = EmbeddingHostType.Face,
+            HostId = sourceFace.Id,
+            Kind = "face.arcface",
+            KindFamily = "face.arcface",
+            Modality = EmbeddingModality.Face,
+            IsSemantic = true,
+            Dim = 3,
+            Vector = new Vector(new[] { 1f, 0f, 0f }),
+            SourceKey = "ext:ai.faces",
+        });
+        context.Embeddings.AddRange(candidateFaces.Select((face, index) => new Embedding
+        {
+            HostType = EmbeddingHostType.Face,
+            HostId = face.Id,
+            Kind = "face.arcface",
+            KindFamily = "face.arcface",
+            Modality = EmbeddingModality.Face,
+            IsSemantic = true,
+            Dim = 3,
+            Vector = new Vector(new[] { 1f, (index + 1) * 0.1f, 0f }),
+            SourceKey = "ext:ai.faces",
+        }));
+        await context.SaveChangesAsync();
+
+        var controller = new FacesController(
+            context,
+            new EmbeddingService(context, []),
+            new StubBlobService(new Dictionary<string, (byte[] Bytes, string ContentType)>()),
+            new FacePerformerPropagationService(context),
+            Array.Empty<IFaceLifecycleParticipant>(),
+            NullLogger<FacesController>.Instance);
+
+        var firstResult = await controller.GetSimilar(sourceFace.Id, "face.arcface", null, null, null, 1, 5, 5, CancellationToken.None);
+        var firstOk = Assert.IsType<OkObjectResult>(firstResult.Result);
+        var firstPage = Assert.IsType<PaginatedResponse<FaceSimilarDto>>(firstOk.Value);
+        var result = await controller.GetSimilar(sourceFace.Id, "face.arcface", null, null, null, 2, 2, 5, CancellationToken.None);
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var page = Assert.IsType<PaginatedResponse<FaceSimilarDto>>(ok.Value);
+
+        Assert.Equal(5, firstPage.TotalCount);
+        Assert.Equal(5, page.TotalCount);
+        Assert.Equal(2, page.Items.Count);
+        Assert.Equal(firstPage.Items.Skip(2).Take(2).Select(face => face.Id), page.Items.Select(face => face.Id));
+    }
+
+    [Fact]
     public async Task FacesController_CanListDetectionsPointingToFace()
     {
         await using var scope = await CreateContextAsync();

--- a/src/Cove.Tests/AiCoreControllerTests.cs
+++ b/src/Cove.Tests/AiCoreControllerTests.cs
@@ -33,7 +33,13 @@ public class AiCoreControllerTests
             new StubBlobService(new Dictionary<string, (byte[] Bytes, string ContentType)>()),
             new FacePerformerPropagationService(context),
             Array.Empty<IFaceLifecycleParticipant>(),
-            NullLogger<FacesController>.Instance);
+            NullLogger<FacesController>.Instance)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
 
         var firstCreate = await controller.Create(new FaceCreateDto("Lead", null, false, "ext:ai.faces"), CancellationToken.None);
         var firstCreated = Assert.IsType<CreatedAtActionResult>(firstCreate.Result);
@@ -80,6 +86,27 @@ public class AiCoreControllerTests
                 Vector = new Vector(new[] { 0.95f, 0.05f, 0f }),
                 SourceKey = "ext:ai.faces",
             });
+        var hostImage = new Image { Title = "Still" };
+        context.Images.Add(hostImage);
+        await context.SaveChangesAsync();
+
+        var representativeDetection = new Detection
+        {
+            HostType = DetectionHostType.Image,
+            HostId = hostImage.Id,
+            FrameWidth = 1200,
+            FrameHeight = 1600,
+            Class = "face",
+            Score = 0.92f,
+            X = 120,
+            Y = 180,
+            W = 240,
+            H = 300,
+            RefKind = "face",
+            RefId = secondFace.Id,
+            SourceKey = "ext:ai.faces",
+        };
+        context.Detections.Add(representativeDetection);
         await context.SaveChangesAsync();
 
         var similarResult = await controller.GetSimilar(firstFace.Id, "face.arcface", null, null, null, 1, 5, 5, CancellationToken.None);
@@ -87,6 +114,7 @@ public class AiCoreControllerTests
         var similarFaces = Assert.IsType<PaginatedResponse<FaceSimilarDto>>(similarOk.Value);
         var match = Assert.Single(similarFaces.Items);
         Assert.Equal(secondFace.Id, match.Id);
+        Assert.Contains($"/api/stream/detection/{representativeDetection.Id}/crop", match.CoverImageUrl, StringComparison.Ordinal);
 
         var mergeResult = await controller.MergeInto(secondFace.Id, new FaceMergeDto(firstFace.Id), CancellationToken.None);
         var mergeOk = Assert.IsType<OkObjectResult>(mergeResult.Result);

--- a/ui/src/pages/FaceDetailPage.tsx
+++ b/ui/src/pages/FaceDetailPage.tsx
@@ -101,7 +101,7 @@ export function FaceDetailPage({ id, onNavigate }: Props) {
       direction: nextFilter.direction,
       page: nextFilter.page ?? 1,
       perPage: nextFilter.perPage ?? 18,
-      k: Math.max(80, (nextFilter.page ?? 1) * (nextFilter.perPage ?? 18) * 4),
+      k: 250,
     }),
   });
 

--- a/ui/src/test/FaceDetailPage.test.tsx
+++ b/ui/src/test/FaceDetailPage.test.tsx
@@ -135,6 +135,7 @@ describe("FaceDetailPage", () => {
 
     expect(await screen.findByText("Nearest neighbors from the face embedding index.")).toBeInTheDocument();
     expect(await screen.findByText("Similar Jane")).toBeInTheDocument();
+    expect(mockFaces.similar).toHaveBeenCalledWith(7, expect.objectContaining({ k: 250 }));
     expect(screen.getAllByRole("combobox").length).toBeGreaterThanOrEqual(2);
 
     fireEvent.click(screen.getByRole("link", { name: "Open face Similar Jane" }));


### PR DESCRIPTION
## Summary

- Uses same LoadFaceCoverFallbackUrlsAsync as other face view already used to fix the missing face thumbnails
- Improves the user experience on similar faces pagination which previously started with 80 faces and the more pages user opened, kept adding until 250 faces were shown. This was now changed to a static 250 to keep the user experience consistent. If there are less than 250 similar faces, then that actual amount is used as the max.

## Linked issue

Closes #37 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Planning, implementing, reviewing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- Add new automated test.
- Run the application with production data where I ran into this issue. After the fix, the face thumbnails were consistently shown. Also I verified the pagination fix with that problematic data and then deleted enough similar faces to get below 250 to verify the case where we don't have 250 similar faces.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
