### PR TITLE
Sort media performers by gender and name

### DIFF
--- a/src/Cove.Api/Controllers/AudiosController.cs
+++ b/src/Cove.Api/Controllers/AudiosController.cs
@@ -6,6 +6,7 @@ using Cove.Api.Services;
 using Cove.Core.Auth;
 using Cove.Core.DTOs;
 using Cove.Core.Entities;
+using Cove.Core.Helpers;
 using Cove.Core.Interfaces;
 using Cove.Data;
 using Cove.Data.Repositories;
@@ -722,14 +723,14 @@ public class AudiosController(CoveContext db, CustomFieldService customFields, I
         audio.Date?.ToString("yyyy-MM-dd"),
         audio.Urls.Select(url => url.Url).ToList(),
         GetEffectiveTags(audio, effectiveTagsByAudioId),
-        audio.AudioPerformers.Where(link => link.Performer != null).Select(link => new PerformerSummaryDto(
-            link.Performer!.Id,
-            link.Performer.Name,
-            link.Performer.Disambiguation,
-            link.Performer.Gender?.ToString(),
-            link.Performer.Birthdate?.ToString("yyyy-MM-dd"),
-            link.Performer.Favorite,
-            EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, link.Performer!))).ToList(),
+        audio.AudioPerformers.Where(link => link.Performer != null).Select(link => link.Performer!).OrderForDisplay().Select(performer => new PerformerSummaryDto(
+            performer.Id,
+            performer.Name,
+            performer.Disambiguation,
+            performer.Gender?.ToString(),
+            performer.Birthdate?.ToString("yyyy-MM-dd"),
+            performer.Favorite,
+            EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, performer))).ToList(),
         audio.Tracks.OrderBy(track => track.OrderIndex).ThenBy(track => track.Id).Select(track => new AudioTrackDto(track.Id, track.OrderIndex, track.Title, track.StartSec, track.EndSec)).ToList(),
         audio.Files.OrderBy(file => file.Id).Select(file => new AudioFileDto(
             file.Id,

--- a/src/Cove.Api/Controllers/GalleriesController.cs
+++ b/src/Cove.Api/Controllers/GalleriesController.cs
@@ -6,6 +6,7 @@ using Cove.Core.Auth;
 using Cove.Core.Common;
 using Cove.Core.DTOs;
 using Cove.Core.Entities;
+using Cove.Core.Helpers;
 using Cove.Core.Enums;
 using Cove.Core.Interfaces;
 
@@ -254,7 +255,7 @@ public class GalleriesController(IGalleryRepository galleryRepo, Data.CoveContex
         g.Organized, g.StudioId, g.Studio?.Name,
         g.Urls.Select(u => u.Url).ToList(),
         g.GalleryTags.Where(gt => gt.Tag != null).Select(gt => TagDtoMapping.MapTagDto(gt.Tag!, GetTagProvenance(provenanceLookup, gt.Tag!.Id))).ToList(),
-        g.GalleryPerformers.Where(gp => gp.Performer != null).Select(gp => new PerformerSummaryDto(gp.Performer!.Id, gp.Performer.Name, gp.Performer.Disambiguation, gp.Performer.Gender?.ToString(), gp.Performer.Birthdate?.ToString("yyyy-MM-dd"), gp.Performer.Favorite, EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, gp.Performer!))).ToList(),
+        g.GalleryPerformers.Where(gp => gp.Performer != null).Select(gp => gp.Performer!).OrderForDisplay().Select(performer => new PerformerSummaryDto(performer.Id, performer.Name, performer.Disambiguation, performer.Gender?.ToString(), performer.Birthdate?.ToString("yyyy-MM-dd"), performer.Favorite, EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, performer))).ToList(),
         imageCount ?? g.ImageCount,
         videoCount ?? g.VideoCount,
         g.VideoGalleries?.Select(sg => sg.VideoId).ToList() ?? [],

--- a/src/Cove.Api/Controllers/ImagesController.cs
+++ b/src/Cove.Api/Controllers/ImagesController.cs
@@ -6,6 +6,7 @@ using Cove.Core.Auth;
 using Cove.Core.Common;
 using Cove.Core.DTOs;
 using Cove.Core.Entities;
+using Cove.Core.Helpers;
 using Cove.Core.Enums;
 using Cove.Core.Interfaces;
 
@@ -241,7 +242,7 @@ public class ImagesController(IImageRepository imageRepo, Data.CoveContext db, I
         i.Date?.ToString("yyyy-MM-dd"),
         i.Urls.Select(u => u.Url).ToList(),
         i.ImageTags.Where(it => it.Tag != null).Select(it => TagDtoMapping.MapTagDto(it.Tag!, GetTagProvenance(provenanceLookup, it.Tag!.Id))).ToList(),
-        i.ImagePerformers.Where(ip => ip.Performer != null).Select(ip => new PerformerSummaryDto(ip.Performer!.Id, ip.Performer.Name, ip.Performer.Disambiguation, ip.Performer.Gender?.ToString(), ip.Performer.Birthdate?.ToString("yyyy-MM-dd"), ip.Performer.Favorite, EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, ip.Performer!))).ToList(),
+        i.ImagePerformers.Where(ip => ip.Performer != null).Select(ip => ip.Performer!).OrderForDisplay().Select(performer => new PerformerSummaryDto(performer.Id, performer.Name, performer.Disambiguation, performer.Gender?.ToString(), performer.Birthdate?.ToString("yyyy-MM-dd"), performer.Favorite, EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, performer))).ToList(),
         galleryCount ?? i.GalleryCount,
         i.ImageGalleries?.Select(ig => ig.GalleryId).ToList() ?? [],
         i.ImageGalleries?.Where(ig => ig.Gallery != null).Select(ig => new GallerySummaryDto(ig.GalleryId, ig.Gallery!.Title, ig.Gallery.Date?.ToString("yyyy-MM-dd"))).ToList() ?? [],
@@ -279,7 +280,7 @@ public class ImagesController(IImageRepository imageRepo, Data.CoveContext db, I
         i.Date?.ToString("yyyy-MM-dd"),
         i.Urls.Select(u => u.Url).ToList(),
         i.ImageTags.Where(it => it.Tag != null).Select(it => TagDtoMapping.MapTagDto(it.Tag!)).ToList(),
-        i.ImagePerformers.Where(ip => ip.Performer != null).Select(ip => new PerformerSummaryDto(ip.Performer!.Id, ip.Performer.Name, ip.Performer.Disambiguation, ip.Performer.Gender?.ToString(), ip.Performer.Birthdate?.ToString("yyyy-MM-dd"), ip.Performer.Favorite, EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, ip.Performer!))).ToList(),
+        i.ImagePerformers.Where(ip => ip.Performer != null).Select(ip => ip.Performer!).OrderForDisplay().Select(performer => new PerformerSummaryDto(performer.Id, performer.Name, performer.Disambiguation, performer.Gender?.ToString(), performer.Birthdate?.ToString("yyyy-MM-dd"), performer.Favorite, EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, performer))).ToList(),
         galleryCount,
         i.ImageGalleries?.Select(ig => ig.GalleryId).ToList() ?? [],
         i.ImageGalleries?.Where(ig => ig.Gallery != null).Select(ig => new GallerySummaryDto(ig.GalleryId, ig.Gallery!.Title, ig.Gallery.Date?.ToString("yyyy-MM-dd"))).ToList() ?? [],

--- a/src/Cove.Api/Controllers/TextsController.cs
+++ b/src/Cove.Api/Controllers/TextsController.cs
@@ -6,6 +6,7 @@ using Cove.Api.Services;
 using Cove.Core.Auth;
 using Cove.Core.DTOs;
 using Cove.Core.Entities;
+using Cove.Core.Helpers;
 using Cove.Core.Interfaces;
 using Cove.Data;
 using Cove.Data.Repositories;
@@ -663,14 +664,14 @@ public class TextsController(CoveContext db, CustomFieldService customFields, Te
         text.Date?.ToString("yyyy-MM-dd"),
         text.Urls.Select(url => url.Url).ToList(),
         text.TextTags.Where(link => link.Tag != null).Select(link => TagDtoMapping.MapTagDto(link.Tag!)).ToList(),
-        text.TextPerformers.Where(link => link.Performer != null).Select(link => new PerformerSummaryDto(
-            link.Performer!.Id,
-            link.Performer.Name,
-            link.Performer.Disambiguation,
-            link.Performer.Gender?.ToString(),
-            link.Performer.Birthdate?.ToString("yyyy-MM-dd"),
-            link.Performer.Favorite,
-            EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, link.Performer!))).ToList(),
+        text.TextPerformers.Where(link => link.Performer != null).Select(link => link.Performer!).OrderForDisplay().Select(performer => new PerformerSummaryDto(
+            performer.Id,
+            performer.Name,
+            performer.Disambiguation,
+            performer.Gender?.ToString(),
+            performer.Birthdate?.ToString("yyyy-MM-dd"),
+            performer.Favorite,
+            EntityImageUrls.PerformerOrNull(ControllerContext.HttpContext, performer))).ToList(),
         text.Files.OrderBy(file => file.Id).Select(file => new TextFileDto(
             file.Id,
             CanReadFiles ? file.Path : string.Empty,

--- a/src/Cove.Api/Controllers/VideosController.cs
+++ b/src/Cove.Api/Controllers/VideosController.cs
@@ -9,6 +9,7 @@ using Cove.Core.Auth;
 using Cove.Core.Common;
 using Cove.Core.DTOs;
 using Cove.Core.Entities;
+using Cove.Core.Helpers;
 using Cove.Core.Interfaces;
 using Cove.Data.Repositories;
 using Cove.Data.Services;
@@ -704,7 +705,7 @@ public class VideosController(IVideoRepository videoRepo, Data.CoveContext db, M
         s.Captions,
         s.Urls.Select(u => u.Url).ToList(),
         GetEffectiveTags(s, effectiveTagsByVideoId),
-        s.VideoPerformers.Where(sp => sp.Performer != null).Select(sp => MapPerformerSummary(sp.Performer!, performerCounts)).ToList(),
+        s.VideoPerformers.Where(sp => sp.Performer != null).Select(sp => sp.Performer!).OrderForDisplay().Select(performer => MapPerformerSummary(performer, performerCounts)).ToList(),
         EffectiveFiles(s).Select(f => new VideoFileDto(
             f.Id,
             CanReadFiles ? f.Path : string.Empty,
@@ -742,7 +743,7 @@ public class VideosController(IVideoRepository videoRepo, Data.CoveContext db, M
         s.Captions,
         s.Urls.Select(u => u.Url).ToList(),
         GetEffectiveTags(s, effectiveTagsByVideoId),
-        s.VideoPerformers.Where(sp => sp.Performer != null).Select(sp => MapPerformerSummary(sp.Performer!, null)).ToList(),
+        s.VideoPerformers.Where(sp => sp.Performer != null).Select(sp => sp.Performer!).OrderForDisplay().Select(performer => MapPerformerSummary(performer, null)).ToList(),
         EffectiveFiles(s).Select(f => new VideoFileDto(
             f.Id,
             CanReadFiles ? f.Path : string.Empty,

--- a/src/Cove.Core/Helpers/PerformerDisplayOrder.cs
+++ b/src/Cove.Core/Helpers/PerformerDisplayOrder.cs
@@ -1,0 +1,23 @@
+using Cove.Core.Entities;
+using Cove.Core.Enums;
+
+namespace Cove.Core.Helpers;
+
+public static class PerformerDisplayOrder
+{
+    public static IOrderedEnumerable<Performer> OrderForDisplay(this IEnumerable<Performer> performers) =>
+        performers
+            .OrderBy(performer => GenderBucket(performer.Gender))
+            .ThenBy(performer => performer.Name, StringComparer.CurrentCulture);
+
+    private static int GenderBucket(GenderEnum? gender) => gender switch
+    {
+        GenderEnum.Female => 0,
+        GenderEnum.TransgenderFemale => 1,
+        GenderEnum.Male => 2,
+        GenderEnum.TransgenderMale => 3,
+        GenderEnum.Intersex => 4,
+        GenderEnum.NonBinary => 5,
+        _ => 6,
+    };
+}

--- a/src/Cove.Tests/PerformerDisplayOrderTests.cs
+++ b/src/Cove.Tests/PerformerDisplayOrderTests.cs
@@ -1,0 +1,42 @@
+using Cove.Core.Entities;
+using Cove.Core.Enums;
+using Cove.Core.Helpers;
+
+namespace Cove.Tests;
+
+public class PerformerDisplayOrderTests
+{
+    [Fact]
+    public void OrderForDisplay_SortsByStashGenderBucketThenName()
+    {
+        Performer[] performers =
+        [
+            new() { Name = "Zulu unknown" },
+            new() { Name = "Zulu male", Gender = GenderEnum.Male },
+            new() { Name = "Beta female", Gender = GenderEnum.Female },
+            new() { Name = "Alpha nonbinary", Gender = GenderEnum.NonBinary },
+            new() { Name = "Alpha male", Gender = GenderEnum.Male },
+            new() { Name = "Alpha female", Gender = GenderEnum.Female },
+            new() { Name = "Alpha intersex", Gender = GenderEnum.Intersex },
+            new() { Name = "Alpha trans man", Gender = GenderEnum.TransgenderMale },
+            new() { Name = "Alpha trans woman", Gender = GenderEnum.TransgenderFemale },
+            new() { Name = "Alpha unknown" },
+        ];
+
+        var orderedNames = performers.OrderForDisplay().Select(performer => performer.Name).ToArray();
+
+        Assert.Equal(
+        [
+            "Alpha female",
+            "Beta female",
+            "Alpha trans woman",
+            "Alpha male",
+            "Zulu male",
+            "Alpha trans man",
+            "Alpha intersex",
+            "Alpha nonbinary",
+            "Alpha unknown",
+            "Zulu unknown",
+        ], orderedNames);
+    }
+}


### PR DESCRIPTION
## Summary

Performers within videos, galleries etc. are now sorted by gender and then by name within the gender bucket instead of using seemingly random order.

## Linked issue

Closes #45 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Planning, implementing testing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- Added a new test.
- Manually tested with a number of different media types and group makeups.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
