### PR TITLE
Show tag creation API errors

### DIFF
--- a/ui/src/pages/TagsPage.tsx
+++ b/ui/src/pages/TagsPage.tsx
@@ -272,7 +272,7 @@ function TagGroupManagerDialog({ open, onClose }: { open: boolean; onClose: () =
 }
 
 /* ── Tag Create Modal ── */
-function TagCreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () => void; onCreated: (id: number) => void }) {
+export function TagCreateModal({ open, onClose, onCreated }: { open: boolean; onClose: () => void; onCreated: (id: number) => void }) {
   const qc = useQueryClient();
   const [form, setForm] = useState({ name: "", description: "", aliases: [] as string[], color: "", tagGroupId: undefined as number | undefined, minOccurrenceSec: undefined as number | undefined, minOccurrencePercent: undefined as number | undefined });
   const [selectedParentIds, setSelectedParentIds] = useState<number[]>([]);
@@ -294,8 +294,12 @@ function TagCreateModal({ open, onClose, onCreated }: { open: boolean; onClose: 
       if (created?.id) onCreated(created.id);
     },
   });
+  const handleClose = () => {
+    mutation.reset();
+    onClose();
+  };
   return (
-    <EditModal title="Create Tag" open={open} onClose={onClose}>
+    <EditModal title="Create Tag" open={open} onClose={handleClose}>
       <Field label="Name">
         <TextInput value={form.name} onChange={(v) => setForm({ ...form, name: v })} />
       </Field>
@@ -344,6 +348,11 @@ function TagCreateModal({ open, onClose, onCreated }: { open: boolean; onClose: 
       <Field label="Custom Fields">
         <CustomFieldsEditor value={customFields} onChange={setCustomFields} entityType="tag" />
       </Field>
+      {mutation.error ? (
+        <div role="alert" className="rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          {mutation.error.message}
+        </div>
+      ) : null}
       <CreateModalActions loading={mutation.isPending} createAnother={createAnother} onCreateAnotherChange={setCreateAnother} onSave={() => mutation.mutate({
           name: form.name,
           description: form.description || undefined,

--- a/ui/src/test/TagCreateModal.test.tsx
+++ b/ui/src/test/TagCreateModal.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TagCreateModal } from "../pages/TagsPage";
+
+const mocks = vi.hoisted(() => ({
+  tagsCreate: vi.fn(),
+  tagGroupsList: vi.fn(),
+}));
+
+vi.mock("../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/client")>();
+  return {
+    ...actual,
+    tags: { ...actual.tags, create: mocks.tagsCreate },
+    tagGroups: { ...actual.tagGroups, list: mocks.tagGroupsList },
+  };
+});
+
+vi.mock("../components/EntityReferenceSelector", () => ({
+  EntityReferenceMultiSelector: () => <div>Parent tag selector</div>,
+}));
+
+vi.mock("../components/shared", () => ({
+  CustomFieldsEditor: () => <div>Custom Fields Editor</div>,
+}));
+
+function renderModal() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TagCreateModal open onClose={vi.fn()} onCreated={vi.fn()} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("TagCreateModal", () => {
+  beforeEach(() => {
+    mocks.tagsCreate.mockReset();
+    mocks.tagGroupsList.mockResolvedValue([]);
+  });
+
+  it("shows a server error in the dialog when tag creation fails", async () => {
+    const user = userEvent.setup();
+    mocks.tagsCreate.mockRejectedValue(new Error("API Error 409: {\"message\":\"Tag 'Existing' already exists\"}"));
+
+    renderModal();
+
+    await user.type(screen.getAllByRole("textbox")[0], "Existing");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Tag 'Existing' already exists");
+    expect(screen.getByRole("heading", { name: "Create Tag" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Tag creation errors are now shown to the user. Previously for example when creating a tag with the same name as previously, the UI didn't show anything and was just seemingly stuck without being able to save. DevTools showed the error in console but not in the UI.

## Linked issue

Closes #42 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Planning, implementing, testing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- Added a new automated test.
- Tried to create a tag with pre-existing name.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
