### PR TITLE
Inline rating and liking for image previews

### DIFF
--- a/ui/src/components/Lightbox.tsx
+++ b/ui/src/components/Lightbox.tsx
@@ -10,10 +10,15 @@ import {
   ZoomOut,
   Maximize2,
   Minimize2,
+  ThumbsUp,
 } from "lucide-react";
-import { playback } from "../api/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { images as imageApi, playback } from "../api/client";
 import { createPlaybackSessionId, trackInteraction } from "../utils/interactionTracking";
 import { pushOverlay } from "../utils/overlayState";
+import { useEntityEngagement } from "../hooks/useEntityEngagement";
+import { InteractiveRating } from "./Rating";
+import type { EntityEngagement } from "../api/types";
 
 // Movement (px) past which a pointer gesture counts as a pan rather than a click. Below it, releasing
 // the pointer toggles zoom; above it the gesture is a drag and must not also toggle zoom on release.
@@ -34,6 +39,7 @@ export interface LightboxProps {
   onClose: () => void;
   slideshowDelay?: number;
   autoPlay?: boolean;
+  canEngage?: boolean;
 }
 
 export function Lightbox({
@@ -43,6 +49,7 @@ export function Lightbox({
   onClose,
   slideshowDelay = 5000,
   autoPlay = false,
+  canEngage = false,
 }: LightboxProps) {
   const [index, setIndex] = useState(initialIndex);
   const [loading, setLoading] = useState(true);
@@ -66,6 +73,22 @@ export function Lightbox({
 
   const count = images.length;
   const current = images[index];
+  const queryClient = useQueryClient();
+  const { engagement, rating, setRating, ratingPending } = useEntityEngagement("image", current?.id ?? 0, { enabled: open && Boolean(current) });
+  const likeMutation = useMutation({
+    mutationFn: (imageId: number) => imageApi.incrementLike(imageId),
+    onSuccess: (likeCount, imageId) => {
+      queryClient.setQueryData(["engagement", "image", imageId], (existing: EntityEngagement | undefined) => existing ? { ...existing, likeCount } : existing);
+      queryClient.invalidateQueries({ queryKey: ["engagement", "image", imageId] });
+      queryClient.invalidateQueries({ queryKey: ["engagement", "image", "batch"] });
+      queryClient.invalidateQueries({ queryKey: ["image", imageId] });
+    },
+  });
+  const likeCount = likeMutation.data ?? engagement?.likeCount ?? 0;
+
+  useEffect(() => {
+    likeMutation.reset();
+  }, [current?.id]);
 
   const trackCurrentImageInteraction = useCallback((kind: string, extraMeta?: Record<string, unknown>) => {
     if (!current) {
@@ -519,6 +542,23 @@ export function Lightbox({
           }}
         />
       </div>
+
+      {current ? (
+        <div className="absolute bottom-[max(1rem,env(safe-area-inset-bottom))] left-4 z-20 flex items-center gap-2 rounded-lg border border-white/15 bg-black/65 px-3 py-2 text-white shadow-lg backdrop-blur-sm">
+          <InteractiveRating value={rating} onChange={setRating} readOnly={!canEngage || ratingPending} />
+          <button
+            type="button"
+            disabled={!canEngage || likeMutation.isPending}
+            onClick={() => likeMutation.mutate(current.id)}
+            className="inline-flex min-h-8 items-center gap-1.5 rounded-md px-2 text-white/80 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label={`Like image (${likeCount} likes)`}
+            title={likeMutation.isPending ? "Saving like" : "Like image"}
+          >
+            <ThumbsUp className={likeCount > 0 ? "h-4 w-4 fill-current text-accent" : "h-4 w-4"} />
+            <span className="text-sm tabular-nums">{likeCount}</span>
+          </button>
+        </div>
+      ) : null}
     </div>,
     document.body,
   );

--- a/ui/src/pages/GalleryDetailPage.tsx
+++ b/ui/src/pages/GalleryDetailPage.tsx
@@ -86,6 +86,7 @@ export function GalleryDetailPage({ id, onNavigate }: Props) {
   const canEngageGallery = canReadEntity("gallery", hasPermission) && (user?.kind === "user" || user?.kind === "system");
   const canDeleteGallery = canDeleteEntity("gallery", hasPermission);
   const canReadGalleryImages = canReadEntity("image", hasPermission);
+  const canEngageImages = canReadGalleryImages && (user?.kind === "user" || user?.kind === "system");
   const canReadPerformers = canReadEntity("performer", hasPermission);
   const canReadStudios = canReadEntity("studio", hasPermission);
   const canReadTags = canReadEntity("tag", hasPermission);
@@ -419,6 +420,7 @@ export function GalleryDetailPage({ id, onNavigate }: Props) {
         initialIndex={lightboxIndex}
         open={lightboxOpen}
         onClose={() => setLightboxOpen(false)}
+        canEngage={canEngageImages}
       />
     </div>
   );

--- a/ui/src/pages/ImageDetailPage.tsx
+++ b/ui/src/pages/ImageDetailPage.tsx
@@ -613,6 +613,7 @@ export function ImageDetailPage({ id, onNavigate }: Props) {
         initialIndex={0}
         open={lightboxOpen && lightboxImages.length > 0}
         onClose={closeLightbox}
+        canEngage={canEngageImage}
       />
       <MediaDetailLayout
         title={<FieldProvenanceHover fieldProvenance={image.fieldProvenance} fieldKey="title">{displayTitle}</FieldProvenanceHover>}

--- a/ui/src/pages/ImagesPage.tsx
+++ b/ui/src/pages/ImagesPage.tsx
@@ -464,6 +464,7 @@ export function ImagesPage({ onNavigate }: Props) {
           onClose={closeLightbox}
           slideshowDelay={config?.ui.slideshowDelay}
           autoPlay={lightboxAutoPlay}
+          canEngage={canEngageImage}
         />
       ) : null}
       {quickViewId !== null ? (

--- a/ui/src/test/LightboxEngagement.test.tsx
+++ b/ui/src/test/LightboxEngagement.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSetRating = vi.fn();
+const mockIncrementLike = vi.fn();
+
+vi.mock("../hooks/useEntityEngagement", () => ({
+  useEntityEngagement: () => ({
+    engagement: { hostId: 152376, likeCount: 1, rating: 40 },
+    rating: 40,
+    setRating: mockSetRating,
+    ratingPending: false,
+  }),
+}));
+
+vi.mock("../components/Rating", () => ({
+  InteractiveRating: ({ onChange, readOnly }: { onChange: (value: number) => void; readOnly?: boolean }) => (
+    <button type="button" disabled={readOnly} onClick={() => onChange(60)}>Rate image 60</button>
+  ),
+}));
+
+vi.mock("../api/client", () => ({
+  images: { incrementLike: (...args: unknown[]) => mockIncrementLike(...args) },
+  playback: { recordIntervals: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("../utils/interactionTracking", () => ({
+  createPlaybackSessionId: () => "session",
+  trackInteraction: vi.fn(),
+}));
+
+import { Lightbox } from "../components/Lightbox";
+
+function renderLightbox(canEngage = true) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Lightbox
+        images={[{ id: 152376, src: "/image.jpg", title: "001.jpg" }]}
+        initialIndex={0}
+        open
+        onClose={vi.fn()}
+        canEngage={canEngage}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIncrementLike.mockResolvedValue(2);
+});
+
+describe("Lightbox image engagement", () => {
+  it("shows rating and like controls in the bottom-left overlay", async () => {
+    renderLightbox();
+
+    fireEvent.click(screen.getByRole("button", { name: "Rate image 60" }));
+    expect(mockSetRating).toHaveBeenCalledWith(60);
+
+    fireEvent.click(screen.getByRole("button", { name: "Like image (1 likes)" }));
+    await waitFor(() => expect(mockIncrementLike).toHaveBeenCalledWith(152376));
+    expect(await screen.findByRole("button", { name: "Like image (2 likes)" })).toBeInTheDocument();
+
+    const controls = screen.getByRole("button", { name: "Rate image 60" }).parentElement;
+    expect(controls).toHaveClass("absolute", "bottom-[max(1rem,env(safe-area-inset-bottom))]", "left-4");
+  });
+
+  it("prevents engagement mutations without permission", () => {
+    renderLightbox(false);
+
+    expect(screen.getByRole("button", { name: "Rate image 60" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Like image (1 likes)" })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Users can use existing image overlay browsing within Images or galleries. Previously rating and liking required opening the images separately. With this PR user can now rate and like images from the overlay view directly.

## Linked issue

Closes #46 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Planning, implementing, testing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- Added new automated tests.
- Manually tested rating and liking on both desktop browser and iPhone in different image views.
- Note that when browsing performer images, overlay view is not used at all even before this PR so this PR doesn't introduce inline rating and liking there. If overlay view is introduced to performer images later, this needs to be added there as well.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
