### PR TITLE
Restore saved defaults in embedded detail-page lists

### DIFF
--- a/ui/src/components/DetailListToolbar.tsx
+++ b/ui/src/components/DetailListToolbar.tsx
@@ -6,7 +6,7 @@ import { reshuffleRandomSort, withSeededRandomSort } from "../utils/seededRandom
 import { toolbarIconButtonClass, toolbarSegmentClass, toolbarSelectClass } from "./listToolbarStyles";
 import { FilterButton, FilterDialog, type CriterionDefinition } from "./FilterDialog";
 import { PageSizeSelect } from "./PageSizeSelect";
-import { SavedFilterMenu } from "./SavedFilterMenu";
+import { SavedFilterMenu, useDefaultSavedFilterOnMount } from "./SavedFilterMenu";
 
 export type DetailListDisplayMode = "grid" | "list" | "wall" | "tagger" | "graph" | "byGroup" | "feed" | "vertical";
 
@@ -125,6 +125,14 @@ export function DetailListToolbar({ filter, onFilterChange, totalCount, sortOpti
 
   const goTo = (nextPage: number) => onFilterChange({ ...filter, page: Math.max(1, Math.min(totalPages, nextPage)) });
   const activeObjectFilter = objectFilter ?? {};
+
+  // Any embedded list that exposes the saved-filter menu must also honor that mode's default.
+  // Keep the surrounding entity constraint outside FindFilter and always start on the first page.
+  useDefaultSavedFilterOnMount(filterDefaultKey ?? filterMode ?? "", (findFilter, defaultObjectFilter) => {
+    if (!filterMode) return;
+    if (findFilter) onFilterChange({ ...filter, ...findFilter, page: 1 });
+    if (defaultObjectFilter && Object.keys(defaultObjectFilter).length > 0) onObjectFilterChange?.(defaultObjectFilter);
+  });
 
   return (
     <>
@@ -301,4 +309,3 @@ function inferCardSizeEntityType(sortOptions?: { value: string; label: string }[
   if (values.has("image_count") && values.has("path")) return "galleries";
   return undefined;
 }
-

--- a/ui/src/components/DetailListToolbar.tsx
+++ b/ui/src/components/DetailListToolbar.tsx
@@ -128,10 +128,12 @@ export function DetailListToolbar({ filter, onFilterChange, totalCount, sortOpti
 
   // Any embedded list that exposes the saved-filter menu must also honor that mode's default.
   // Keep the surrounding entity constraint outside FindFilter and always start on the first page.
-  useDefaultSavedFilterOnMount(filterDefaultKey ?? filterMode ?? "", (findFilter, defaultObjectFilter) => {
+  useDefaultSavedFilterOnMount(filterDefaultKey ?? filterMode ?? "", (findFilter, defaultObjectFilter, defaultUIOptions) => {
     if (!filterMode) return;
     if (findFilter) onFilterChange({ ...filter, ...findFilter, page: 1 });
     if (defaultObjectFilter && Object.keys(defaultObjectFilter).length > 0) onObjectFilterChange?.(defaultObjectFilter);
+    const defaultDisplayMode = typeof defaultUIOptions?.displayMode === "string" ? defaultUIOptions.displayMode : undefined;
+    if (defaultDisplayMode) onDisplayModeChange?.(defaultDisplayMode as DetailListDisplayMode);
   });
 
   return (
@@ -202,8 +204,13 @@ export function DetailListToolbar({ filter, onFilterChange, totalCount, sortOpti
             defaultFilterKey={filterDefaultKey}
             currentFilter={filter}
             currentObjectFilter={activeObjectFilter}
+            currentUIOptions={displayMode ? { displayMode } : undefined}
             onApplyFilter={(nextFilter) => onFilterChange(withSeededRandomSort(filter, { ...nextFilter, page: 1 }))}
             onApplyObjectFilter={onObjectFilterChange}
+            onApplyUIOptions={(options) => {
+              const nextDisplayMode = typeof options.displayMode === "string" ? options.displayMode : undefined;
+              if (nextDisplayMode) onDisplayModeChange?.(nextDisplayMode as DetailListDisplayMode);
+            }}
           />
         ) : null}
 

--- a/ui/src/components/SavedFilterMenu.tsx
+++ b/ui/src/components/SavedFilterMenu.tsx
@@ -54,18 +54,23 @@ export function getDefaultFilter(mode: string): { findFilter?: FindFilter; objec
 /**
  * Applies a mode's default saved filter exactly once on mount. Lets embedded list views inside
  * detail pages (a performer's videos, a studio's galleries, …) honor the user's default the same
- * way the top-level list pages do. `apply` receives the default's findFilter/objectFilter (if any).
+ * way the top-level list pages do. `apply` receives the default's findFilter, objectFilter, and
+ * UI options (if any).
  */
 export function useDefaultSavedFilterOnMount(
   mode: string,
-  apply: (findFilter: FindFilter | undefined, objectFilter: Record<string, unknown> | undefined) => void,
+  apply: (
+    findFilter: FindFilter | undefined,
+    objectFilter: Record<string, unknown> | undefined,
+    uiOptions: Record<string, unknown> | undefined,
+  ) => void,
 ) {
   const appliedRef = useRef(false);
   useEffect(() => {
     if (appliedRef.current) return;
     appliedRef.current = true;
     const def = getDefaultFilter(mode);
-    if (def) apply(def.findFilter, def.objectFilter);
+    if (def) apply(def.findFilter, def.objectFilter, def.uiOptions);
     // Intentionally mount-only: the default is a starting point the user can then change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -288,4 +293,3 @@ export function SavedFilterMenu({
     </div>
   );
 }
-

--- a/ui/src/pages/GalleryDetailPage.tsx
+++ b/ui/src/pages/GalleryDetailPage.tsx
@@ -437,7 +437,7 @@ function GalleryVideosPanel({ galleryId, filter, setFilter, onNavigate }: {
   // Honor the user's default "videos" saved filter for this embedded list; the gallery constraint
   // stays applied separately via the query params.
   useDefaultSavedFilterOnMount("videos", (findFilter, defaultObjectFilter) => {
-    if (findFilter) setFilter({ ...filter, sort: findFilter.sort ?? filter.sort, direction: findFilter.direction ?? filter.direction, page: 1 });
+    if (findFilter) setFilter({ ...filter, ...findFilter, page: 1 });
     if (defaultObjectFilter && Object.keys(defaultObjectFilter).length > 0) setObjectFilter(defaultObjectFilter);
   });
   const hasObjectFilter = Object.keys(objectFilter).length > 0;

--- a/ui/src/pages/GalleryDetailPage.tsx
+++ b/ui/src/pages/GalleryDetailPage.tsx
@@ -42,6 +42,13 @@ interface Props {
 
 type TabKey = "images" | "videos" | "fileinfo" | (string & {});
 
+// Gallery contents are bounded collections (typically no more than hundreds of items), so users can
+// safely default them to Infinite without also making the global Images/Videos pages attempt to load
+// potentially millions of records. Filters created with "Save current filter" are available in both
+// gallery and global lists, while "Set current as default" is stored separately for gallery contents.
+const GALLERY_IMAGES_DEFAULT_FILTER_KEY = "gallery-images";
+const GALLERY_VIDEOS_DEFAULT_FILTER_KEY = "gallery-videos";
+
 export function GalleryDetailPage({ id, onNavigate }: Props) {
   const { hasPermission, user } = useAuth();
   const [imageFilter, setImageFilter] = useState<FindFilter>({ page: 1, perPage: 60, direction: "desc" });
@@ -468,6 +475,7 @@ function GalleryVideosPanel({ galleryId, filter, setFilter, onNavigate }: {
       objectFilter={objectFilter}
       onObjectFilterChange={setObjectFilter}
       filterMode="videos"
+      filterDefaultKey={GALLERY_VIDEOS_DEFAULT_FILTER_KEY}
       allowInfinitePageSize
       displayMode={displayMode}
       onDisplayModeChange={setDisplayMode}
@@ -533,7 +541,7 @@ function GalleryImagesPanel({ galleryId, filter, setFilter, objectFilter, setObj
       objectFilter={objectFilter}
       onObjectFilterChange={setObjectFilter}
       filterMode="images"
-      filterDefaultKey="gallery-images"
+      filterDefaultKey={GALLERY_IMAGES_DEFAULT_FILTER_KEY}
       allowInfinitePageSize
       displayMode={displayMode}
       onDisplayModeChange={setDisplayMode}

--- a/ui/src/pages/GalleryDetailPage.tsx
+++ b/ui/src/pages/GalleryDetailPage.tsx
@@ -11,7 +11,6 @@ import { ExtensionSlot } from "../router/RouteRegistry";
 import { Lightbox, type LightboxImage } from "../components/Lightbox";
 import { InteractiveRating } from "../components/Rating";
 import { DetailListToolbar } from "../components/DetailListToolbar";
-import { useDefaultSavedFilterOnMount } from "../components/SavedFilterMenu";
 import { IMAGE_CRITERIA, VIDEO_CRITERIA } from "../components/FilterDialog";
 import { PerformerBadgeRow } from "../components/EntityCards";
 import { EntityHeroLayout, HERO_PRIMARY_ACTION_BUTTON_CLASS, HERO_ACTION_BUTTON_CLASS } from "../components/EntityHeroLayout";
@@ -434,12 +433,6 @@ function GalleryVideosPanel({ galleryId, filter, setFilter, onNavigate }: {
   const { displayMode, setDisplayMode, availableDisplayModes } = useRelatedEntityDisplayMode("videos");
   const [quickViewId, setQuickViewId] = useState<number | null>(null);
   const [objectFilter, setObjectFilter] = useState<Record<string, unknown>>({});
-  // Honor the user's default "videos" saved filter for this embedded list; the gallery constraint
-  // stays applied separately via the query params.
-  useDefaultSavedFilterOnMount("videos", (findFilter, defaultObjectFilter) => {
-    if (findFilter) setFilter({ ...filter, ...findFilter, page: 1 });
-    if (defaultObjectFilter && Object.keys(defaultObjectFilter).length > 0) setObjectFilter(defaultObjectFilter);
-  });
   const hasObjectFilter = Object.keys(objectFilter).length > 0;
   const { data, isLoading, infinitePageSize, infiniteQuery, infiniteFilterKey, fetchAllIds, loadMore } = useDetailListQuery<Video>({
     queryKey: ["gallery-videos", galleryId, objectFilter],
@@ -517,14 +510,6 @@ function GalleryImagesPanel({ galleryId, filter, setFilter, objectFilter, setObj
 }) {
   const [quickViewId, setQuickViewId] = useState<number | null>(null);
   const { displayMode, setDisplayMode, availableDisplayModes } = useRelatedEntityDisplayMode("images");
-  // Honor the user's default filter for images-in-a-gallery. This is keyed separately from the standalone
-  // Images list ("gallery-images" vs "images") so the two views can have independent defaults — e.g. a
-  // random + resolution-filtered Images page, but filename-sorted full listings inside a gallery. The
-  // gallery constraint stays applied separately via the query params.
-  useDefaultSavedFilterOnMount("gallery-images", (findFilter, defaultObjectFilter) => {
-    if (findFilter) setFilter({ ...filter, ...findFilter, page: 1 });
-    if (defaultObjectFilter && Object.keys(defaultObjectFilter).length > 0) setObjectFilter(defaultObjectFilter);
-  });
   const items = galleryImages?.items ?? [];
   const { selectedIds, toggle, selectAll, selectAllPending, selectShown, selectNone } = useDetailListSelection({ items, infinitePageSize, infiniteFilterKey, fetchAllIds, resetKeyParts: [objectFilter] });
   const selecting = selectedIds.size > 0;

--- a/ui/src/pages/GalleryDetailPage.tsx
+++ b/ui/src/pages/GalleryDetailPage.tsx
@@ -522,7 +522,7 @@ function GalleryImagesPanel({ galleryId, filter, setFilter, objectFilter, setObj
   // random + resolution-filtered Images page, but filename-sorted full listings inside a gallery. The
   // gallery constraint stays applied separately via the query params.
   useDefaultSavedFilterOnMount("gallery-images", (findFilter, defaultObjectFilter) => {
-    if (findFilter) setFilter({ ...filter, sort: findFilter.sort ?? filter.sort, direction: findFilter.direction ?? filter.direction, page: 1 });
+    if (findFilter) setFilter({ ...filter, ...findFilter, page: 1 });
     if (defaultObjectFilter && Object.keys(defaultObjectFilter).length > 0) setObjectFilter(defaultObjectFilter);
   });
   const items = galleryImages?.items ?? [];

--- a/ui/src/pages/PerformerDetailPage.tsx
+++ b/ui/src/pages/PerformerDetailPage.tsx
@@ -12,7 +12,6 @@ import { AspectRatingsPanel } from "../components/AspectRatingsPanel";
 import { InteractiveRating } from "../components/Rating";
 import { QuickViewDialog } from "../components/QuickViewDialog";
 import { DetailListToolbar } from "../components/DetailListToolbar";
-import { useDefaultSavedFilterOnMount } from "../components/SavedFilterMenu";
 import { useMultiSelect } from "../hooks/useMultiSelect";
 import { BulkSelectionActions } from "../components/BulkSelectionActions";
 import { useExtensionTabs } from "../components/useExtensionTabs";
@@ -863,12 +862,6 @@ function PerformerVideosPanel({ performerId, filter, setFilter, onNavigate }: {
   const [quickViewId, setQuickViewId] = useState<number | null>(null);
   const [objectFilter, setObjectFilter] = useState<Record<string, unknown>>({});
   const [selectAllMatchingPending, setSelectAllMatchingPending] = useState(false);
-  // Honor the user's default "videos" saved filter for this embedded list (sort/direction + object
-  // filter), while the performer constraint stays applied separately via the query params.
-  useDefaultSavedFilterOnMount("videos", (findFilter, defaultObjectFilter) => {
-    if (findFilter) setFilter({ ...filter, sort: findFilter.sort ?? filter.sort, direction: findFilter.direction ?? filter.direction, page: 1 });
-    if (defaultObjectFilter && Object.keys(defaultObjectFilter).length > 0) setObjectFilter(defaultObjectFilter);
-  });
   const hasObjectFilter = Object.keys(objectFilter).length > 0;
   const { data, isLoading, infinitePageSize, infiniteQuery, infiniteFilterKey, fetchAllIds, loadMore } = useDetailListQuery<Video>({
     queryKey: ["performer-videos", performerId, objectFilter],
@@ -1194,4 +1187,3 @@ function EmptyPanel({ icon, message }: { icon: React.ReactNode; message: string 
     </div>
   );
 }
-

--- a/ui/src/test/DetailListToolbar.test.tsx
+++ b/ui/src/test/DetailListToolbar.test.tsx
@@ -1,10 +1,25 @@
-import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DetailListToolbar } from "../components/DetailListToolbar";
 
+vi.mock("../api/client", () => ({
+  savedFilters: {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+function renderWithQueryClient(ui: React.ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
+  localStorage.clear();
 });
 
 describe("DetailListToolbar", () => {
@@ -59,5 +74,35 @@ describe("DetailListToolbar", () => {
     );
 
     expect(screen.getByRole("slider")).toHaveAttribute("max", "8");
+  });
+
+  it("applies the complete saved default for an embedded list", async () => {
+    localStorage.setItem("cove-default-filter-galleries", JSON.stringify({
+      findFilter: { page: 7, perPage: 40, sort: "title", direction: "asc", q: "summer" },
+      objectFilter: { favorite: true },
+    }));
+    const onFilterChange = vi.fn();
+    const onObjectFilterChange = vi.fn();
+
+    renderWithQueryClient(
+      <DetailListToolbar
+        filter={{ page: 3, perPage: 18, direction: "desc" }}
+        onFilterChange={onFilterChange}
+        totalCount={100}
+        sortOptions={[{ value: "title", label: "Title" }]}
+        filterMode="galleries"
+        objectFilter={{}}
+        onObjectFilterChange={onObjectFilterChange}
+      />,
+    );
+
+    await waitFor(() => expect(onFilterChange).toHaveBeenCalledWith({
+      page: 1,
+      perPage: 40,
+      sort: "title",
+      direction: "asc",
+      q: "summer",
+    }));
+    expect(onObjectFilterChange).toHaveBeenCalledWith({ favorite: true });
   });
 });

--- a/ui/src/test/DetailListToolbar.test.tsx
+++ b/ui/src/test/DetailListToolbar.test.tsx
@@ -80,9 +80,11 @@ describe("DetailListToolbar", () => {
     localStorage.setItem("cove-default-filter-galleries", JSON.stringify({
       findFilter: { page: 7, perPage: 40, sort: "title", direction: "asc", q: "summer" },
       objectFilter: { favorite: true },
+      uiOptions: { displayMode: "list" },
     }));
     const onFilterChange = vi.fn();
     const onObjectFilterChange = vi.fn();
+    const onDisplayModeChange = vi.fn();
 
     renderWithQueryClient(
       <DetailListToolbar
@@ -93,6 +95,9 @@ describe("DetailListToolbar", () => {
         filterMode="galleries"
         objectFilter={{}}
         onObjectFilterChange={onObjectFilterChange}
+        displayMode="grid"
+        onDisplayModeChange={onDisplayModeChange}
+        availableDisplayModes={["grid", "list"]}
       />,
     );
 
@@ -104,5 +109,6 @@ describe("DetailListToolbar", () => {
       q: "summer",
     }));
     expect(onObjectFilterChange).toHaveBeenCalledWith({ favorite: true });
+    expect(onDisplayModeChange).toHaveBeenCalledWith("list");
   });
 });

--- a/ui/src/test/GalleryDetailPage.test.tsx
+++ b/ui/src/test/GalleryDetailPage.test.tsx
@@ -211,6 +211,20 @@ describe("GalleryDetailPage", () => {
     expect(await screen.findByTestId("detail-page-size")).toHaveTextContent("20");
   });
 
+  it("applies the saved gallery video page size", async () => {
+    localStorage.setItem("cove-default-filter-videos", JSON.stringify({
+      findFilter: { sort: "date", direction: "desc", perPage: 40 },
+    }));
+    mockGalleries.get.mockResolvedValue(buildGallery({ videoCount: 1 }));
+    mockImages.find.mockResolvedValue({ items: [{ id: 91, title: "Cover Frame" }], totalCount: 1 });
+    mockVideos.find.mockResolvedValue({ items: [{ id: 4, title: "Video One" }], totalCount: 1 });
+
+    renderPage();
+    fireEvent.click(await screen.findByRole("tab", { name: /videos/i }));
+
+    expect(await screen.findByTestId("detail-page-size")).toHaveTextContent("40");
+  });
+
   it("renders the shared layout with images, videos, and file info tabs", async () => {
     mockGalleries.get.mockResolvedValue(buildGallery());
     mockImages.find.mockResolvedValue({

--- a/ui/src/test/GalleryDetailPage.test.tsx
+++ b/ui/src/test/GalleryDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GalleryDetailPage } from "../pages/GalleryDetailPage";
 
@@ -47,6 +47,11 @@ vi.mock("../api/client", () => ({
   images: mockImages,
   videos: mockVideos,
   entityImages: mockEntityImages,
+  savedFilters: {
+    list: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    delete: vi.fn(),
+  },
 }));
 
 vi.mock("../hooks/useEntityEngagement", () => ({
@@ -95,12 +100,6 @@ vi.mock("../components/GalleryDownloadDialog", () => ({
 
 vi.mock("../components/Rating", () => ({
   InteractiveRating: ({ value }: { value: number }) => <div>Rating {value}</div>,
-}));
-
-vi.mock("../components/DetailListToolbar", () => ({
-  DetailListToolbar: ({ filter }: { filter: { perPage?: number } }) => (
-    <div>Detail Toolbar <span data-testid="detail-page-size">{filter.perPage}</span></div>
-  ),
 }));
 
 vi.mock("../components/EntityCards", () => ({
@@ -208,7 +207,7 @@ describe("GalleryDetailPage", () => {
 
     renderPage();
 
-    expect(await screen.findByTestId("detail-page-size")).toHaveTextContent("20");
+    await waitFor(() => expect(screen.getByTitle("Items per page")).toHaveValue("20"));
   });
 
   it("applies the saved gallery video page size", async () => {
@@ -222,7 +221,7 @@ describe("GalleryDetailPage", () => {
     renderPage();
     fireEvent.click(await screen.findByRole("tab", { name: /videos/i }));
 
-    expect(await screen.findByTestId("detail-page-size")).toHaveTextContent("40");
+    await waitFor(() => expect(screen.getByTitle("Items per page")).toHaveValue("40"));
   });
 
   it("renders the shared layout with images, videos, and file info tabs", async () => {

--- a/ui/src/test/GalleryDetailPage.test.tsx
+++ b/ui/src/test/GalleryDetailPage.test.tsx
@@ -98,7 +98,9 @@ vi.mock("../components/Rating", () => ({
 }));
 
 vi.mock("../components/DetailListToolbar", () => ({
-  DetailListToolbar: () => <div>Detail Toolbar</div>,
+  DetailListToolbar: ({ filter }: { filter: { perPage?: number } }) => (
+    <div>Detail Toolbar <span data-testid="detail-page-size">{filter.perPage}</span></div>
+  ),
 }));
 
 vi.mock("../components/EntityCards", () => ({
@@ -193,6 +195,20 @@ function renderPage() {
 describe("GalleryDetailPage", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("applies the saved gallery image page size", async () => {
+    localStorage.setItem("cove-default-filter-gallery-images", JSON.stringify({
+      findFilter: { sort: "path", direction: "asc", perPage: 20 },
+    }));
+    mockGalleries.get.mockResolvedValue(buildGallery());
+    mockImages.find.mockResolvedValue({ items: [{ id: 91, title: "Cover Frame" }], totalCount: 78 });
+    mockVideos.find.mockResolvedValue({ items: [], totalCount: 0 });
+
+    renderPage();
+
+    expect(await screen.findByTestId("detail-page-size")).toHaveTextContent("20");
   });
 
   it("renders the shared layout with images, videos, and file info tabs", async () => {
@@ -244,4 +260,3 @@ describe("GalleryDetailPage", () => {
     expect(await screen.findByText("Edit Gallery Modal")).toBeInTheDocument();
   });
 });
-

--- a/ui/src/test/GalleryDetailPage.test.tsx
+++ b/ui/src/test/GalleryDetailPage.test.tsx
@@ -212,6 +212,9 @@ describe("GalleryDetailPage", () => {
 
   it("applies the saved gallery video page size", async () => {
     localStorage.setItem("cove-default-filter-videos", JSON.stringify({
+      findFilter: { sort: "date", direction: "desc", perPage: 20 },
+    }));
+    localStorage.setItem("cove-default-filter-gallery-videos", JSON.stringify({
       findFilter: { sort: "date", direction: "desc", perPage: 40 },
     }));
     mockGalleries.get.mockResolvedValue(buildGallery({ videoCount: 1 }));


### PR DESCRIPTION
## Summary

Fix saved defaults for lists embedded in gallery and performer detail pages.

- Restore the complete saved filter state, including page size, search, object filters, and display mode, while always resetting to page 1.
- Apply defaults consistently to every embedded list that exposes “Set current as default.”
- Keep gallery content defaults separate from global Images and Videos defaults. Gallery collections are typically bounded, so users can safely choose Infinite without making global lists attempt to load potentially millions of records.
- Keep filters created with “Save current filter” available across gallery and global lists of the same entity type.
- Add regression coverage for gallery image and video page sizes, gallery-specific versus global defaults, and shared embedded-toolbar restoration.

## Linked issue

Closes #57

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [x] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Reproduction and diagnosis, implementation, regression tests, code review, and PR drafting.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

Focused regression tests:

```bash
npm --prefix ui test -- --run src/test/GalleryDetailPage.test.tsx src/test/DetailListToolbar.test.tsx
```

Result: 2 test files passed, 8 tests passed.

Full UI test suite:

```bash
npm --prefix ui test
```

Result: 53 test files passed, 280 tests passed. JSDOM emitted its existing unsupported media playback and document navigation notices.

Production UI build and TypeScript compilation:

```bash
npm --prefix ui run build
```

Result: passed. The build retained existing Rollup warnings about SignalR annotations, generated Lucide exports, circular chunk dependencies, and chunk size.

Manual verification in Chromium against the devbox gallery `/gallery/2178`:

1. Changed the gallery Images page size from 60 to 20.
2. Selected “Set current as default.”
3. Reloaded the gallery.
4. Confirmed the page-size selector remained at 20.

The gallery video regression test additionally sets conflicting defaults (`videos` at 20 and `gallery-videos` at 40) and confirms Gallery → Videos restores 40.

## Checklist

- [x] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [x] Builds and existing tests pass.
- [x] I added or updated tests where it makes sense.
- [x] I updated docs where needed.
- [x] This PR is focused and does not bundle unrelated changes.