### PR TITLE
Clickable link to get to metadata server

### DIFF
--- a/src/Cove.Api/Controllers/TagsController.cs
+++ b/src/Cove.Api/Controllers/TagsController.cs
@@ -166,6 +166,7 @@ public class TagsController(ITagRepository tagRepo, Data.CoveContext db, CustomF
             .AsNoTracking()
             .Include(t => t.Aliases)
             .Include(t => t.TagGroup)
+            .Include(t => t.RemoteIds)
             .Include(t => t.ParentRelations).ThenInclude(tp => tp.Parent).ThenInclude(parent => parent!.TagGroup)
             .Include(t => t.ChildRelations).ThenInclude(tp => tp.Child).ThenInclude(child => child!.TagGroup)
             .AsSplitQuery()
@@ -941,4 +942,3 @@ public class TagsController(ITagRepository tagRepo, Data.CoveContext db, CustomF
         return Ok(result);
     }
 }
-

--- a/src/Cove.Tests/TagsControllerSegmentTests.cs
+++ b/src/Cove.Tests/TagsControllerSegmentTests.cs
@@ -12,6 +12,31 @@ namespace Cove.Tests;
 public class TagsControllerSegmentTests
 {
     [Fact]
+    public async Task TagDetail_IncludesRemoteIds()
+    {
+        await using var context = CreateContext();
+        var tag = new Tag { Name = "Linked tag" };
+        tag.RemoteIds.Add(new TagRemoteId
+        {
+            Endpoint = "https://stashdb.org/graphql",
+            RemoteId = "remote-tag-1",
+        });
+        context.Tags.Add(tag);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        var controller = new TagsController(null!, context, new CustomFieldService(context), null!);
+
+        var result = await controller.GetById(tag.Id, CancellationToken.None);
+        var detail = Assert.IsType<OkObjectResult>(result.Result).Value as TagDetailDto;
+
+        Assert.NotNull(detail);
+        var remoteId = Assert.Single(detail.RemoteIds!);
+        Assert.Equal("https://stashdb.org/graphql", remoteId.Endpoint);
+        Assert.Equal("remote-tag-1", remoteId.RemoteId);
+    }
+
+    [Fact]
     public async Task TagDetail_UsesVideoSegmentCountsAndReturnsTagSegments()
     {
         await using var context = CreateContext();
@@ -357,4 +382,3 @@ public class TagsControllerSegmentTests
         }
     }
 }
-

--- a/ui/src/components/MetadataServerLinks.tsx
+++ b/ui/src/components/MetadataServerLinks.tsx
@@ -1,0 +1,67 @@
+import { ExternalLink } from "lucide-react";
+
+type MetadataEntityType = "scenes" | "performers" | "studios" | "tags";
+
+interface RemoteId {
+  endpoint: string;
+  remoteId: string;
+}
+
+interface MetadataServer {
+  endpoint: string;
+  name?: string;
+}
+
+export function metadataServerEntityUrl(endpoint: string, entityType: MetadataEntityType, remoteId: string): string | null {
+  try {
+    const url = new URL(endpoint);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    const graphqlPath = url.pathname.match(/^(.*\/)?graphql\/?$/i);
+    if (!graphqlPath) return null;
+    url.pathname = `${graphqlPath[1] ?? "/"}${entityType}/${encodeURIComponent(remoteId)}`;
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function metadataServerLabel(endpoint: string, servers: MetadataServer[]): string {
+  const normalizedEndpoint = endpoint.trim().replace(/\/$/, "").toLowerCase();
+  const configuredName = servers.find((server) => server.endpoint.trim().replace(/\/$/, "").toLowerCase() === normalizedEndpoint)?.name?.trim();
+  if (configuredName) return configuredName;
+  try {
+    return new URL(endpoint).hostname.replace(/^www\./i, "");
+  } catch {
+    return endpoint;
+  }
+}
+
+export function MetadataServerLinks({ remoteIds, entityType, metadataServers = [], className = "contents" }: { remoteIds?: RemoteId[]; entityType: MetadataEntityType; metadataServers?: MetadataServer[]; className?: string }) {
+  const links = (remoteIds ?? []).flatMap((remoteId) => {
+    const href = metadataServerEntityUrl(remoteId.endpoint, entityType, remoteId.remoteId);
+    return href ? [{ ...remoteId, href, label: metadataServerLabel(remoteId.endpoint, metadataServers) }] : [];
+  });
+
+  if (links.length === 0) return null;
+
+  return (
+    <div className={className}>
+      {links.map((link) => (
+        <a
+          key={`${link.endpoint}-${link.remoteId}`}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-xs text-accent transition hover:border-accent/60 hover:text-accent-hover"
+          title={`Open ${link.label} metadata page`}
+          aria-label={`Open ${link.label} metadata page`}
+        >
+          <ExternalLink className="h-3 w-3" />
+          <span>{link.label}</span>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/pages/PerformerDetailPage.tsx
+++ b/ui/src/pages/PerformerDetailPage.tsx
@@ -33,6 +33,8 @@ import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useAuth } from "../auth/AuthContext";
 import { canDeleteEntity, canReadEntity, canWriteEntity, filterItemsByPermission, hasAnyPermission } from "../auth/visibility";
 import { withRequiredMultiId } from "../utils/detailRelationFilters";
+import { MetadataServerLinks } from "../components/MetadataServerLinks";
+import { useAppConfig } from "../state/AppConfigContext";
 
 interface Props {
   id: number;
@@ -72,6 +74,7 @@ const TEXT_SORT = [
 ];
 
 export function PerformerDetailPage({ id, onNavigate }: Props) {
+  const { config } = useAppConfig();
   const { hasPermission, user } = useAuth();
   const { data: performer, isLoading } = useQuery({
     queryKey: ["performer", id],
@@ -299,9 +302,10 @@ export function PerformerDetailPage({ id, onNavigate }: Props) {
               {performer.careerStart && <InfoItem label="Career" value={`${performer.careerStart}${performer.careerEnd ? ` – ${performer.careerEnd}` : " – present"}`} fieldProvenance={performer.fieldProvenance} fieldKey={["career_start", "careerStart"]} />}
             </div>
 
-            {performer.urls.length > 0 ? (
+            {(performer.urls.length > 0 || performer.remoteIds.length > 0) ? (
               <FieldProvenanceHover fieldProvenance={performer.fieldProvenance} fieldKey="urls" block className="mt-4 space-y-2">
                 <div ref={urlsRef} className={`flex flex-wrap gap-2 ${urlsExpanded ? "" : "max-h-[4.5rem] overflow-hidden"}`}>
+                  <MetadataServerLinks remoteIds={performer.remoteIds} entityType="performers" metadataServers={config?.scraping?.metadataServers} />
                   {performer.urls.map((url, i) => (
                     <a key={i} href={url} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-xs text-accent hover:border-accent/60 hover:text-accent-hover">
                       <ExternalLink className="h-3 w-3" />
@@ -1194,4 +1198,3 @@ function EmptyPanel({ icon, message }: { icon: React.ReactNode; message: string 
     </div>
   );
 }
-

--- a/ui/src/pages/StudioDetailPage.tsx
+++ b/ui/src/pages/StudioDetailPage.tsx
@@ -28,6 +28,7 @@ import { PERFORMER_SORT_OPTIONS } from "../components/performerSortOptions";
 import { useEntityEngagement } from "../hooks/useEntityEngagement";
 import { useDetailListQuery } from "../hooks/useDetailListQuery";
 import { useDetailListSelection } from "../hooks/useDetailListSelection";
+import { MetadataServerLinks } from "../components/MetadataServerLinks";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useAuth } from "../auth/AuthContext";
 import { canDeleteEntity, canReadEntity, canWriteEntity, filterItemsByPermission } from "../auth/visibility";
@@ -293,9 +294,10 @@ export function StudioDetailPage({ id, onNavigate }: Props) {
                 ))}
               </div>
             ) : null}
-            {studio.urls.length > 0 ? (
+            {(studio.urls.length > 0 || studio.remoteIds.length > 0) ? (
               <FieldProvenanceHover fieldProvenance={studio.fieldProvenance} fieldKey="urls" block className="mt-3">
                 <div className="flex flex-wrap gap-2">
+                  <MetadataServerLinks remoteIds={studio.remoteIds} entityType="studios" metadataServers={metadataServers} />
                   {studio.urls.map((url, index) => (
                     <a key={index} href={url} target="_blank" rel="noopener noreferrer" className="inline-flex max-w-xs items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-xs text-accent hover:border-accent/60 hover:text-accent-hover">
                       <LinkIcon className="h-3 w-3 flex-shrink-0" />
@@ -906,4 +908,3 @@ function EmptyPanel({ icon, message }: { icon: React.ReactNode; message: string 
     </div>
   );
 }
-

--- a/ui/src/pages/TagDetailPage.tsx
+++ b/ui/src/pages/TagDetailPage.tsx
@@ -15,6 +15,8 @@ import { BulkSelectionActions } from "../components/BulkSelectionActions";
 import { useExtensionTabs } from "../components/useExtensionTabs";
 import { EntityDetailTabs } from "../components/EntityDetailTabs";
 import { EntityHeroLayout, HERO_ACTION_BUTTON_CLASS, HERO_PRIMARY_ACTION_BUTTON_CLASS } from "../components/EntityHeroLayout";
+import { MetadataServerLinks } from "../components/MetadataServerLinks";
+import { useAppConfig } from "../state/AppConfigContext";
 import { InteractiveRating } from "../components/Rating";
 import { CoverImageDialog } from "../components/CoverImageDialog";
 import { FloatingActionMenu } from "../components/FloatingActionMenu";
@@ -87,6 +89,7 @@ interface Props {
 type TabKey = "videos" | "performers" | "images" | "galleries" | "audios" | "texts" | "segments" | "studios" | "groups" | (string & {});
 
 export function TagDetailPage({ id, onNavigate }: Props) {
+  const { config } = useAppConfig();
   const { hasPermission, user } = useAuth();
   const { data: tag, isLoading } = useQuery({
     queryKey: ["tag", id],
@@ -265,6 +268,7 @@ export function TagDetailPage({ id, onNavigate }: Props) {
             <div className="mb-3 shrink-0">
               <InteractiveRating value={tagRating} onChange={(value) => setTagRating(value)} readOnly={!canEngageTag} />
             </div>
+            <MetadataServerLinks className="mb-3 flex flex-wrap gap-2" remoteIds={tag.remoteIds} entityType="tags" metadataServers={config?.scraping?.metadataServers} />
             <CustomFieldsDisplay customFields={tag.customFields} entityType="tag" />
           </>
         )}
@@ -742,4 +746,3 @@ function EmptyPanel({ icon, message }: { icon: React.ReactNode; message: string 
     </div>
   );
 }
-

--- a/ui/src/pages/VideoDetailPage.tsx
+++ b/ui/src/pages/VideoDetailPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { useState, useRef, useEffect, useCallback, Fragment, useMemo, lazy, Suspense } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog";
-import type { Detection, Face, PerformerSummary, ResolvedSpan, Video, VideoUpdate, Segment, TagApplication, TagProvenance } from "../api/types";
+import type { Detection, Face, MetadataServer, PerformerSummary, ResolvedSpan, Video, VideoUpdate, Segment, TagApplication, TagProvenance } from "../api/types";
 import { ExtensionSlot } from "../router/RouteRegistry";
 import { AspectRatingsPanel } from "../components/AspectRatingsPanel";
 import { InteractiveRating } from "../components/Rating";
@@ -48,6 +48,7 @@ import { VideoVisualSimilarityPanel, useVideoVisualSimilarityAvailable } from ".
 import { VideoAudioSimilarityPanel, useVideoAudioSimilarityAvailable } from "../components/AudioSimilarityPanel";
 import { EntityReferenceMultiSelector, EntityReferenceSelector, EntityReferenceValue } from "../components/EntityReferenceSelector";
 import { useDocumentTitle } from "../hooks/useDocumentTitle";
+import { MetadataServerLinks } from "../components/MetadataServerLinks";
 
 const GenerateDialog = lazy(() => import("../components/GenerateDialog").then((module) => ({ default: module.GenerateDialog })));
 const DetailMergeDialog = lazy(() => import("../components/DetailMergeDialog").then((module) => ({ default: module.DetailMergeDialog })));
@@ -648,6 +649,7 @@ export function VideoDetailPage({ id, initialSeekTo, onNavigate }: Props) {
   const activeTabContent = activeTab === "details" ? (
     <DetailsTab
       video={video}
+      metadataServers={config?.scraping?.metadataServers}
       onNavigate={onNavigate}
       videoFaces={videoFaces}
       onMarkFaceNotPresent={canWriteFaces ? (faceId) => markFaceNotPresentMut.mutate(faceId) : undefined}
@@ -995,7 +997,7 @@ function describeTagEvidence(tag: { effectiveDurationSec?: number | null; effect
 }
 
 // Details Tab Content
-export function DetailsTab({ video, onNavigate, videoFaces = [], onMarkFaceNotPresent, markingFaceId, onRequestReportTag }: { video: Video; onNavigate: (r: any) => void; videoFaces?: Array<{ face: Face; detectionCount: number }>; onMarkFaceNotPresent?: (faceId: number) => void; markingFaceId?: number; onRequestReportTag?: (tag: any) => void }) {
+export function DetailsTab({ video, onNavigate, metadataServers, videoFaces = [], onMarkFaceNotPresent, markingFaceId, onRequestReportTag }: { video: Video; onNavigate: (r: any) => void; metadataServers?: MetadataServer[]; videoFaces?: Array<{ face: Face; detectionCount: number }>; onMarkFaceNotPresent?: (faceId: number) => void; markingFaceId?: number; onRequestReportTag?: (tag: any) => void }) {
   const { engagementById: performerEngagement } = useEntityEngagementBatch("performer", video?.performers?.map((p) => p.id) ?? []);
   return (
     <div className="space-y-4">
@@ -1179,11 +1181,13 @@ export function DetailsTab({ video, onNavigate, videoFaces = [], onMarkFaceNotPr
       )}
 
       {/* URLs */}
-      {video.urls && video.urls.length > 0 && (
+      {(video.urls?.length > 0 || video.remoteIds?.length > 0) && (
         <div>
           <h6 className="text-sm text-muted mb-2">URLs</h6>
-          <FieldProvenanceHover fieldProvenance={video.fieldProvenance} fieldKey="urls" block>
-            <div className="space-y-1">
+          <div className="space-y-2">
+            <MetadataServerLinks className="flex flex-wrap gap-2" remoteIds={video.remoteIds} entityType="scenes" metadataServers={metadataServers} />
+            {video.urls?.length > 0 ? <FieldProvenanceHover fieldProvenance={video.fieldProvenance} fieldKey="urls" block>
+              <div className="space-y-1">
               {video.urls.map((url: string, i: number) => (
                 <a
                   key={i}
@@ -1195,8 +1199,9 @@ export function DetailsTab({ video, onNavigate, videoFaces = [], onMarkFaceNotPr
                   {url}
                 </a>
               ))}
-            </div>
-          </FieldProvenanceHover>
+              </div>
+            </FieldProvenanceHover> : null}
+          </div>
         </div>
       )}
 
@@ -2348,4 +2353,3 @@ function VideoEditPanel({ video, onSaved, onNavigate, onRequestReportTag }: { vi
     </div>
   );
 }
-

--- a/ui/src/test/MetadataServerLinks.test.tsx
+++ b/ui/src/test/MetadataServerLinks.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { MetadataServerLinks, metadataServerEntityUrl } from "../components/MetadataServerLinks";
+
+describe("MetadataServerLinks", () => {
+  it("builds stash-box entity URLs from GraphQL endpoints", () => {
+    expect(metadataServerEntityUrl("https://stashdb.org/graphql", "scenes", "scene-1"))
+      .toBe("https://stashdb.org/scenes/scene-1");
+    expect(metadataServerEntityUrl("https://example.test/api/graphql/", "performers", "performer-1"))
+      .toBe("https://example.test/api/performers/performer-1");
+    expect(metadataServerEntityUrl("https://stashdb.org/graphql", "studios", "studio-1"))
+      .toBe("https://stashdb.org/studios/studio-1");
+  });
+
+  it("strips endpoint query data and rejects unsafe or unsupported endpoints", () => {
+    expect(metadataServerEntityUrl("https://example.test/graphql?token=secret#fragment", "tags", "tag-1"))
+      .toBe("https://example.test/tags/tag-1");
+    expect(metadataServerEntityUrl("javascript:alert(1)", "tags", "tag-1")).toBeNull();
+    expect(metadataServerEntityUrl("https://example.test/api", "tags", "tag-1")).toBeNull();
+    expect(metadataServerEntityUrl("not a URL", "tags", "tag-1")).toBeNull();
+  });
+
+  it("renders one accessible external link for every remote ID", () => {
+    render(
+      <MetadataServerLinks
+        entityType="tags"
+        metadataServers={[
+          { endpoint: "https://stashdb.org/graphql", name: "StashDB" },
+          { endpoint: "https://theporndb.net/graphql", name: "ThePornDB" },
+        ]}
+        remoteIds={[
+          { endpoint: "https://stashdb.org/graphql", remoteId: "tag-1" },
+          { endpoint: "https://theporndb.net/graphql", remoteId: "tag-2" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Open StashDB metadata page" })).toHaveAttribute(
+      "href",
+      "https://stashdb.org/tags/tag-1",
+    );
+    expect(screen.getByRole("link", { name: "Open ThePornDB metadata page" })).toHaveAttribute(
+      "href",
+      "https://theporndb.net/tags/tag-2",
+    );
+    expect(screen.getByText("StashDB")).toBeVisible();
+  });
+
+  it("renders no layout wrapper when there are no usable remote IDs", () => {
+    const { container } = render(
+      <MetadataServerLinks
+        className="mb-3"
+        entityType="tags"
+        remoteIds={[{ endpoint: "not a URL", remoteId: "tag-1" }]}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to Cove! Please fill out this template.
For paid contributions, see the payout rules in CONTRIBUTING.md.
-->

## Summary

Previously user didn't have any clickable links to get to StashDB or other metadata servers. User had to get the remote IDs from edit view and then reconstruct the link manually.

## Linked issue

Closes #36 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [X] AI was used for this PR.
  - **Model(s):** GPT-5.6
  - **Where / how:** Planning, implementation, testing.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- Added new automated tests.
- Manually verified the metadata server links in each of the entity types both with and without remote IDs.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [X] Builds and existing tests pass.
- [X] I added or updated tests where it makes sense.
- [X] I updated docs where needed.
- [X] This PR is focused and does not bundle unrelated changes.
