### PR TITLE
Standardize date formatting across the UI

### DIFF
--- a/ui/src/components/BulkEditDialog.tsx
+++ b/ui/src/components/BulkEditDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { X } from "lucide-react";
 import { InteractiveRating } from "./Rating";
+import { IsoDateInput } from "./IsoDateInput";
 import type { BulkUpdateMode } from "../api/types";
 import { tagGroups } from "../api/client";
 import { StudioSelector } from "./StudioSelector";
@@ -195,8 +196,7 @@ function BulkFieldEditor({
             />
           )}
           {field.type === "date" && (
-            <input
-              type="date"
+            <IsoDateInput
               value={(value as string) ?? ""}
               onChange={(e) => onValueChange(e.target.value)}
               className="bg-input border border-border rounded px-2 py-1 text-xs text-foreground focus:outline-none focus:border-accent"

--- a/ui/src/components/CustomFields.tsx
+++ b/ui/src/components/CustomFields.tsx
@@ -8,6 +8,8 @@ import {
   parseEntityReferenceIds,
 } from "./EntityReferenceSelector";
 import { useCustomFieldDefinitions } from "../hooks/useCustomFieldDefinitions";
+import { formatDate } from "../utils/dateFormat";
+import { IsoDateInput } from "./IsoDateInput";
 
 export function CustomFieldsDisplay({
   customFields,
@@ -236,16 +238,18 @@ function ConfiguredFieldInput({
     longText: "text",
     number: "number",
     boolean: "text",
-    date: "date",
-    timestamp: "datetime-local",
+    date: "text",
+    timestamp: "text",
     url: "url",
     enum: "text",
     duration: "number",
     percent: "number",
   };
 
+  const Input = definition.type === "date" || definition.type === "timestamp" ? IsoDateInput : "input";
   return (
-    <input
+    <Input
+      {...(definition.type === "timestamp" ? { pickerType: "datetime-local" as const } : {})}
       type={inputType[definition.type] ?? "text"}
       value={serializeScalarValue(value)}
       onChange={(event) => onChange(event.target.value)}
@@ -310,12 +314,8 @@ function formatDateValue(value: unknown): string {
     return String(value ?? "");
   }
 
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-
-  return parsed.toLocaleDateString();
+  const formatted = formatDate(value);
+  return formatted === "Invalid Date" ? value : formatted;
 }
 
 function normalizeDefinedFieldValue(value: string, type: CustomFieldType): unknown {

--- a/ui/src/components/EntityCards.tsx
+++ b/ui/src/components/EntityCards.tsx
@@ -1834,7 +1834,7 @@ export function FaceTile({ face, onClick, selected, onSelect, selecting, childre
       body={(
         <>
           <h3 className="card-title truncate text-sm font-semibold text-foreground group-hover:text-accent">{title}</h3>
-          <div className="truncate text-xs text-secondary">{face.performerId && face.performerName ? `Updated ${new Date(face.updatedAt).toLocaleDateString()}` : face.performerName || `Updated ${new Date(face.updatedAt).toLocaleDateString()}`}</div>
+          <div className="truncate text-xs text-secondary">{face.performerId && face.performerName ? `Updated ${formatDate(face.updatedAt)}` : face.performerName || `Updated ${formatDate(face.updatedAt)}`}</div>
         </>
       )}
       footer={(

--- a/ui/src/components/FieldProvenanceHover.tsx
+++ b/ui/src/components/FieldProvenanceHover.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState, type ReactNode, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import type { FieldProvenance } from "../api/types";
+import { formatDateTime } from "../utils/dateFormat";
 
 export function FieldProvenanceHover({
   fieldProvenance,
@@ -308,7 +309,7 @@ function formatProvenanceDate(value?: string) {
   }
 
   try {
-    return new Date(value).toLocaleString();
+    return formatDateTime(value);
   } catch {
     return value;
   }

--- a/ui/src/components/FilterDialog.tsx
+++ b/ui/src/components/FilterDialog.tsx
@@ -3,6 +3,7 @@ import { useQueries, useQuery } from "@tanstack/react-query";
 import { X, ChevronDown, ChevronRight, Search, Pin, PinOff, Plus, Minus, Star } from "lucide-react";
 import { tags as tagsApi, performers as performersApi, studios as studiosApi, groups as groupsApi, galleries as galleriesApi, videos as videosApi, tagGroups as tagGroupsApi, faces as facesApi } from "../api/client";
 import { GroupedTagOptionList } from "./TagSelector";
+import { IsoDateInput } from "./IsoDateInput";
 import { EntityReferenceSelector } from "./EntityReferenceSelector";
 import {
   convertToRatingFormat,
@@ -1738,8 +1739,7 @@ function DateEditor({ value, onChange, modifiers }: { value?: DateCriterion; onC
       <ModifierSelector modifiers={modifiers} selected={modifier} onSelect={(m) => onChange({ value: value?.value ?? "", modifier: m })} />
       {!isNull && (
         <div className="flex items-center gap-2">
-          <input
-            type="date"
+          <IsoDateInput
             value={value?.value ?? ""}
             onChange={(e) => onChange({ value: e.target.value, value2: value?.value2, modifier })}
             className="bg-input border border-border rounded px-2 py-1 text-xs text-foreground focus:outline-none focus:border-accent"
@@ -1747,8 +1747,7 @@ function DateEditor({ value, onChange, modifiers }: { value?: DateCriterion; onC
           {isBetween && (
             <>
               <span className="text-xs text-muted">and</span>
-              <input
-                type="date"
+              <IsoDateInput
                 value={value?.value2 ?? ""}
                 onChange={(e) => onChange({ value: value?.value, value2: e.target.value, modifier })}
                 className="bg-input border border-border rounded px-2 py-1 text-xs text-foreground focus:outline-none focus:border-accent"
@@ -1795,8 +1794,8 @@ function TimestampEditor({ value, onChange, modifiers }: { value?: TimestampCrit
       />
       {!isNull && (
         <div className="flex items-center gap-2">
-          <input
-            type="datetime-local"
+          <IsoDateInput
+            pickerType="datetime-local"
             value={value?.value ?? ensureTimestampValue(value?.value)}
             onChange={(e) => onChange({ value: e.target.value, value2: value?.value2, modifier })}
             className="bg-input border border-border rounded px-2 py-1 text-xs text-foreground focus:outline-none focus:border-accent"
@@ -1804,8 +1803,8 @@ function TimestampEditor({ value, onChange, modifiers }: { value?: TimestampCrit
           {isBetween && (
             <>
               <span className="text-xs text-muted">and</span>
-              <input
-                type="datetime-local"
+              <IsoDateInput
+                pickerType="datetime-local"
                 value={value?.value2 ?? ensureTimestampValue(value?.value2)}
                 onChange={(e) => onChange({ value: value?.value, value2: e.target.value, modifier })}
                 className="bg-input border border-border rounded px-2 py-1 text-xs text-foreground focus:outline-none focus:border-accent"
@@ -2317,4 +2316,3 @@ export function FilterButton({
     </button>
   );
 }
-

--- a/ui/src/components/IsoDateInput.tsx
+++ b/ui/src/components/IsoDateInput.tsx
@@ -1,0 +1,52 @@
+import { useRef, type InputHTMLAttributes } from "react";
+import { CalendarDays } from "lucide-react";
+
+type IsoDateInputProps = InputHTMLAttributes<HTMLInputElement> & {
+  pickerType?: "date" | "datetime-local";
+};
+
+export function IsoDateInput({ pickerType = "date", className = "", value, onChange, disabled, type: _type, inputMode: _inputMode, placeholder: _placeholder, ...props }: IsoDateInputProps) {
+  const pickerRef = useRef<HTMLInputElement>(null);
+  const placeholder = pickerType === "date" ? "yyyy-MM-dd" : "yyyy-MM-ddTHH:mm";
+
+  const openPicker = () => {
+    const picker = pickerRef.current;
+    if (!picker) return;
+    picker.value = typeof value === "string" ? value : "";
+    if (typeof picker.showPicker === "function") picker.showPicker();
+    else picker.click();
+  };
+
+  return (
+    <span className="relative block w-full">
+      <input
+        {...props}
+        type="text"
+        inputMode="numeric"
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        className={`${className} w-full pr-10`.trim()}
+      />
+      <button
+        type="button"
+        aria-label="Choose date"
+        title="Choose date"
+        disabled={disabled}
+        onClick={openPicker}
+        className="absolute inset-y-0 right-0 flex w-10 items-center justify-center text-secondary hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <CalendarDays className="h-4 w-4" />
+      </button>
+      <input
+        ref={pickerRef}
+        type={pickerType}
+        tabIndex={-1}
+        aria-hidden="true"
+        className="pointer-events-none absolute h-px w-px opacity-0"
+        onChange={onChange}
+      />
+    </span>
+  );
+}

--- a/ui/src/components/JobCard.tsx
+++ b/ui/src/components/JobCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Loader2, CheckCircle, XCircle, Ban, Clock, Trash2, ChevronUp, ChevronDown } from "lucide-react";
 import type { JobInfo } from "../api/types";
+import { formatDateTime } from "../utils/dateFormat";
 
 /** Format a millisecond duration as a compact human string (e.g. "45s", "3m 20s", "1h 15m"). */
 export function formatJobDuration(ms: number): string {
@@ -140,11 +141,11 @@ export function JobCard({ job, variant = "drawer", onCancel, onMoveUp, onMoveDow
           {isFinished && job.completedAt && (
             <div className="mt-1 space-y-0.5">
               <p className="text-xs text-muted">
-                Started {new Date(job.startedAt).toLocaleString()}
+                Started {formatDateTime(job.startedAt)}
                 {" · "}
                 Took {formatJobDuration(new Date(job.completedAt).getTime() - new Date(job.startedAt).getTime())}
                 {" · "}
-                Finished {new Date(job.completedAt).toLocaleTimeString()}
+                Finished {formatDateTime(job.completedAt)}
               </p>
               {counts && <p className="text-xs text-muted">{counts}</p>}
             </div>

--- a/ui/src/components/ListPage.tsx
+++ b/ui/src/components/ListPage.tsx
@@ -6,6 +6,7 @@ import { tags as tagsApi, performers as performersApi, studios as studiosApi, gr
 import { ExtensionSlot } from "../router/RouteRegistry";
 import { SavedFilterMenu } from "./SavedFilterMenu";
 import { InfiniteScrollSentinel } from "./InfiniteScrollSentinel";
+import { IsoDateInput } from "./IsoDateInput";
 import { FilterDialog, FilterButton, type CriterionDefinition, type CriterionType, type EntityType, type FilterDialogCustomSection } from "./FilterDialog";
 import { EntityReferenceSelector, getEntityReferenceLabel, isEntityReferenceType, parseEntityReferenceId } from "./EntityReferenceSelector";
 import { useResolvedKeybindingOverrides } from "../hooks/useResolvedKeybindingOverrides";
@@ -493,18 +494,20 @@ function CustomFieldValueInput({
     longText: "text",
     number: "number",
     boolean: "text",
-    date: "date",
-    timestamp: "datetime-local",
+    date: "text",
+    timestamp: "text",
     url: "url",
     enum: "text",
     duration: "number",
     percent: "number",
   };
 
+  const Input = definition.type === "date" || definition.type === "timestamp" ? IsoDateInput : "input";
   return (
     <label className="block text-xs text-muted">
       {label}
-      <input
+      <Input
+        {...(definition.type === "timestamp" ? { pickerType: "datetime-local" as const } : {})}
         type={inputType[definition.type] ?? "text"}
         disabled={disabled}
         value={value}
@@ -1567,4 +1570,3 @@ function getPageNumbers(current: number, total: number): number[] {
   pages.push(total);
   return pages;
 }
-

--- a/ui/src/components/MediaScrapeDialog.tsx
+++ b/ui/src/components/MediaScrapeDialog.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, Loader2, Search, Sparkles, X } from "lucide-react";
 import { scrapeAttempts, system } from "../api/client";
 import type { ScrapeAttempt, ScraperSummary } from "../api/types";
 import { useAppConfig } from "../state/AppConfigContext";
+import { formatDateTime } from "../utils/dateFormat";
 import {
   buildMatchInfo,
   buildRelationActionMap,
@@ -94,11 +95,8 @@ const URL_PLACEHOLDERS: Record<MediaEntityType, string> = {
 };
 
 function formatAttemptTime(value: string) {
-  try {
-    return new Date(value).toLocaleString();
-  } catch {
-    return value;
-  }
+  const formatted = formatDateTime(value);
+  return formatted === "Invalid Date" ? value : formatted;
 }
 
 function statusTone(status: string) {

--- a/ui/src/components/TagProvenanceHover.tsx
+++ b/ui/src/components/TagProvenanceHover.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import type { TagProvenance } from "../api/types";
+import { formatDateTime } from "../utils/dateFormat";
 
 // Hover-intent timings: the popup opens only after a deliberate pause (sweeping the cursor across a
 // tag list must not flash popups) and closes shortly after the pointer settles outside both the chip
@@ -262,7 +263,7 @@ function formatTagProvenanceDate(value?: string) {
   }
 
   try {
-    return new Date(value).toLocaleString();
+    return formatDateTime(value);
   } catch {
     return value;
   }

--- a/ui/src/components/shared.tsx
+++ b/ui/src/components/shared.tsx
@@ -312,16 +312,8 @@ export function formatFileSize(bytes: number): string {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
 }
 
-export function formatDate(dateStr?: string): string {
-  if (!dateStr) return "";
-  try {
-    return new Date(dateStr).toLocaleDateString();
-  } catch {
-    return dateStr;
-  }
-}
+export { formatDate } from "../utils/dateFormat";
 
 export function getResolutionLabel(width: number, height: number): string | null {
   return getResolutionBucketLabel(width, height);
 }
-

--- a/ui/src/pages/AudioEditPanel.tsx
+++ b/ui/src/pages/AudioEditPanel.tsx
@@ -7,6 +7,7 @@ import { PerformerContextTagEditor, buildPerformerContextTagIds, syncPerformerCo
 import { CustomFieldsEditor, buildTagProvenanceById } from "../components/shared";
 import { StringListEditor } from "../components/StringListEditor";
 import { StudioSelector } from "../components/StudioSelector";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { EntityReferenceMultiSelector, EntityReferenceValue } from "../components/EntityReferenceSelector";
 import { getEditableTagIds, getLockedTagIds, mergeTagIds } from "../utils/tags";
 
@@ -91,7 +92,7 @@ export function AudioEditPanel({ audio, onSaved }: Props) {
           <input value={title} onChange={(event) => setTitle(event.target.value)} className={inputCls} />
         </Field>
         <Field label="Date" fieldProvenance={audio.fieldProvenance} fieldKey="date">
-          <input type="date" value={date} onChange={(event) => setDate(event.target.value)} className={inputCls} />
+          <IsoDateInput value={date} onChange={(event) => setDate(event.target.value)} className={inputCls} />
         </Field>
       </div>
 

--- a/ui/src/pages/AudiosPage.tsx
+++ b/ui/src/pages/AudiosPage.tsx
@@ -9,6 +9,7 @@ import { CreateModalActions, EditModal, Field, TextArea, TextInput } from "../co
 import { ListPage, type DisplayMode } from "../components/ListPage";
 import { CardSelectionToggle, RouteCardLinkOverlay } from "../components/RouteCardLinkOverlay";
 import { CustomFieldsEditor, formatDuration } from "../components/shared";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { AudioTile, EntityReferencePopovers } from "../components/EntityCards";
 import { useAuth } from "../auth/AuthContext";
 import { canWriteEntity } from "../auth/visibility";
@@ -314,7 +315,7 @@ function AudioCreateModal({ open, onClose, onCreated }: { open: boolean; onClose
 
       <div className="grid grid-cols-2 gap-4">
         <Field label="Title"><TextInput value={title} onChange={setTitle} placeholder="Audio title" /></Field>
-        <Field label="Date"><input type="date" value={date} onChange={(event) => setDate(event.target.value)} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" /></Field>
+        <Field label="Date"><IsoDateInput value={date} onChange={(event) => setDate(event.target.value)} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" /></Field>
       </div>
       <Field label="Studio Code"><TextInput value={code} onChange={setCode} placeholder="Audio code" /></Field>
       <Field label="Details"><TextArea value={details} onChange={setDetails} placeholder="Audio notes" rows={3} /></Field>

--- a/ui/src/pages/GalleriesPage.tsx
+++ b/ui/src/pages/GalleriesPage.tsx
@@ -10,6 +10,7 @@ import { useEntityEngagementBatch } from "../hooks/useEntityEngagementBatch";
 import { FolderOpen, Images as ImagesIcon, Trash2, Loader2, Edit, Box, Film, Check, Search, Download } from "lucide-react";
 import { GalleryTile, PopoverButton, VideosPopoverContent, ImagesPopoverContent, EntityReferencePopovers } from "../components/EntityCards";
 import { GALLERY_CRITERIA } from "../components/FilterDialog";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { BulkEditDialog, GALLERY_BULK_FIELDS } from "../components/BulkEditDialog";
 import { getDefaultFilter } from "../components/SavedFilterMenu";
 import { useListUrlState } from "../hooks/useListUrlState";
@@ -410,7 +411,7 @@ function GalleryCreateModal({ open, onClose, onCreated }: { open: boolean; onClo
         <TextInput value={form.code} onChange={(v) => setForm({ ...form, code: v })} />
       </Field>
       <Field label="Date">
-        <input type="date" value={form.date} onChange={(event) => setForm({ ...form, date: event.target.value })} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" />
+        <IsoDateInput value={form.date} onChange={(event) => setForm({ ...form, date: event.target.value })} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" />
       </Field>
       <Field label="Photographer">
         <TextInput value={form.photographer} onChange={(v) => setForm({ ...form, photographer: v })} />

--- a/ui/src/pages/GalleryEditModal.tsx
+++ b/ui/src/pages/GalleryEditModal.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { galleries } from "../api/client";
 import type { Gallery, GalleryUpdate } from "../api/types";
 import { EditModal, Field, TextInput, TextArea, SaveButton } from "../components/EditModal";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { CustomFieldsEditor, buildTagProvenanceById } from "../components/shared";
 import { StringListEditor } from "../components/StringListEditor";
 import { StudioSelector } from "../components/StudioSelector";
@@ -73,8 +74,7 @@ export function GalleryEditModal({ gallery, open, onClose }: Props) {
           <TextInput value={form.code} onChange={(v) => setForm({ ...form, code: v })} />
         </Field>
         <Field label="Date" fieldProvenance={gallery.fieldProvenance} fieldKey="date">
-          <input
-            type="date"
+          <IsoDateInput
             value={form.date}
             onChange={(event) => setForm({ ...form, date: event.target.value })}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"

--- a/ui/src/pages/GroupEditModal.tsx
+++ b/ui/src/pages/GroupEditModal.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { groups } from "../api/client";
 import type { Group, GroupUpdate } from "../api/types";
 import { EditModal, Field, TextInput, TextArea, SaveButton } from "../components/EditModal";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { CustomFieldsEditor, buildTagProvenanceById } from "../components/shared";
 import { StringListEditor } from "../components/StringListEditor";
 import { StudioSelector } from "../components/StudioSelector";
@@ -181,8 +182,7 @@ export function GroupEditModal({ group, open, onClose }: Props) {
           <TextInput value={director} onChange={setDirector} placeholder="Director name" />
         </Field>
         <Field label="Date" fieldProvenance={group.fieldProvenance} fieldKey="date">
-          <input
-            type="date"
+          <IsoDateInput
             value={date}
             onChange={(e) => setDate(e.target.value)}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"
@@ -233,4 +233,3 @@ function splitAliases(value?: string) {
 function joinAliases(values: string[]) {
   return values.map((alias) => alias.trim()).filter(Boolean).join(", ");
 }
-

--- a/ui/src/pages/GroupsPage.tsx
+++ b/ui/src/pages/GroupsPage.tsx
@@ -10,6 +10,7 @@ import { useEntityEngagementBatch } from "../hooks/useEntityEngagementBatch";
 import { Layers, Trash2, Loader2, Edit } from "lucide-react";
 import { GroupTile } from "../components/EntityCards";
 import { GROUP_CRITERIA } from "../components/FilterDialog";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { BulkEditDialog, GROUP_BULK_FIELDS } from "../components/BulkEditDialog";
 import { getDefaultFilter } from "../components/SavedFilterMenu";
 import { useListUrlState } from "../hooks/useListUrlState";
@@ -399,7 +400,7 @@ function GroupCreateModal({ open, onClose, onCreated }: { open: boolean; onClose
         <DynamicGroupFilterEditor queryJson={form.queryJson} onChange={(queryJson) => setForm({ ...form, queryJson })} />
       ) : null}
       <Field label="Date">
-        <input type="date" value={form.date} onChange={(event) => setForm({ ...form, date: event.target.value })} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" />
+        <IsoDateInput value={form.date} onChange={(event) => setForm({ ...form, date: event.target.value })} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" />
       </Field>
       <Field label="Director">
         <TextInput value={form.director} onChange={(v) => setForm({ ...form, director: v })} />

--- a/ui/src/pages/ImageEditModal.tsx
+++ b/ui/src/pages/ImageEditModal.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { images, system } from "../api/client";
 import type { DownloaderMatch, Image, ImageCreate, VideoGroupInput } from "../api/types";
 import { CreateModalActions, EditModal, Field, TextInput, TextArea, SaveButton } from "../components/EditModal";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { RatingField } from "../components/Rating";
 import { CustomFieldsEditor, buildTagProvenanceById } from "../components/shared";
 import { StringListEditor } from "../components/StringListEditor";
@@ -233,8 +234,7 @@ function ImageMetadataModal({ title, open, onClose, initialState, onSubmit, isPe
           <TextInput value={form.title} onChange={(value) => setForm({ ...form, title: value })} placeholder="Image title" />
         </Field>
         <Field label="Date" fieldProvenance={image?.fieldProvenance} fieldKey="date">
-          <input
-            type="date"
+          <IsoDateInput
             value={form.date}
             onChange={(e) => setForm({ ...form, date: e.target.value })}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"
@@ -565,4 +565,3 @@ export function ImageCreateModal({ open, onClose, onCreated }: ImageCreateProps)
     </>
   );
 }
-

--- a/ui/src/pages/PerformerEditModal.tsx
+++ b/ui/src/pages/PerformerEditModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { performers, tags as tagsApi } from "../api/client";
 import type { Performer, PerformerUpdate } from "../api/types";
 import { EditModal, Field, TextInput, TextArea, NumberInput, SaveButton } from "../components/EditModal";
@@ -199,16 +200,14 @@ export function PerformerEditModal({ performer, open, onClose }: Props) {
           </select>
         </Field>
         <Field label="Birthdate" fieldProvenance={performer.fieldProvenance} fieldKey="birthdate">
-          <input
-            type="date"
+          <IsoDateInput
             value={birthdate}
             onChange={(e) => setBirthdate(e.target.value)}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"
           />
         </Field>
         <Field label="Death Date" fieldProvenance={performer.fieldProvenance} fieldKey="deathDate">
-          <input
-            type="date"
+          <IsoDateInput
             value={deathDate}
             onChange={(e) => setDeathDate(e.target.value)}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"
@@ -275,16 +274,14 @@ export function PerformerEditModal({ performer, open, onClose }: Props) {
 
       <div className="grid grid-cols-2 gap-4">
         <Field label="Career Start" fieldProvenance={performer.fieldProvenance} fieldKey="careerStart">
-          <input
-            type="date"
+          <IsoDateInput
             value={careerStart}
             onChange={(e) => setCareerStart(e.target.value)}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"
           />
         </Field>
         <Field label="Career End" fieldProvenance={performer.fieldProvenance} fieldKey="careerEnd">
-          <input
-            type="date"
+          <IsoDateInput
             value={careerEnd}
             onChange={(e) => setCareerEnd(e.target.value)}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"

--- a/ui/src/pages/PerformersPage.tsx
+++ b/ui/src/pages/PerformersPage.tsx
@@ -9,6 +9,7 @@ import { GENDER_OPTIONS } from "./PerformerEditModal";
 import { toggleOptionsFromEvent, useMultiSelect, type BoundMultiSelectToggleHandler, type MultiSelectToggleHandler } from "../hooks/useMultiSelect";
 import { useEntityEngagementBatch } from "../hooks/useEntityEngagementBatch";
 import { PERFORMER_CRITERIA } from "../components/FilterDialog";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { Users, Heart, Merge, User } from "lucide-react";
 import { MergeDialog } from "../components/MergeDialog";
 import { PerformerTagger } from "../components/PerformerTagger";
@@ -361,10 +362,10 @@ function PerformerCreateModal({ open, onClose, onCreated }: { open: boolean; onC
             </select>
           </Field>
           <Field label="Birthdate">
-            <input type="date" value={birthdate} onChange={(e) => setBirthdate(e.target.value)} className={SELECT_CLASS} />
+            <IsoDateInput value={birthdate} onChange={(e) => setBirthdate(e.target.value)} className={SELECT_CLASS} />
           </Field>
           <Field label="Death Date">
-            <input type="date" value={deathDate} onChange={(e) => setDeathDate(e.target.value)} className={SELECT_CLASS} />
+            <IsoDateInput value={deathDate} onChange={(e) => setDeathDate(e.target.value)} className={SELECT_CLASS} />
           </Field>
           <Field label="Country">
             <TextInput value={country} onChange={setCountry} placeholder="e.g. US" />

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import * as signalR from "@microsoft/signalr";
+import { formatDate } from "../components/shared";
 import {
   ChevronDown,
   ChevronRight,
@@ -7080,7 +7081,7 @@ function FindAndInstallExtensions() {
               >
                 {selectedExtension.versions.map(v => (
                   <option key={v.version} value={v.version}>
-                    v{v.version}{v.releasedAt ? ` — ${new Date(v.releasedAt).toLocaleDateString()}` : ""}
+                    v{v.version}{v.releasedAt ? ` — ${formatDate(v.releasedAt)}` : ""}
                   </option>
                 ))}
               </select>
@@ -7297,6 +7298,5 @@ function ExtBadge({ label }: { label: string }) {
     </span>
   );
 }
-
 
 

--- a/ui/src/pages/TextEditPanel.tsx
+++ b/ui/src/pages/TextEditPanel.tsx
@@ -7,6 +7,7 @@ import { PerformerContextTagEditor, buildPerformerContextTagIds, syncPerformerCo
 import { CustomFieldsEditor, buildTagProvenanceById } from "../components/shared";
 import { StringListEditor } from "../components/StringListEditor";
 import { StudioSelector } from "../components/StudioSelector";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { EntityReferenceMultiSelector, EntityReferenceValue } from "../components/EntityReferenceSelector";
 
 interface Props {
@@ -83,7 +84,7 @@ export function TextEditPanel({ text, onSaved }: Props) {
           <input value={title} onChange={(event) => setTitle(event.target.value)} className={inputCls} />
         </Field>
         <Field label="Date" fieldProvenance={text.fieldProvenance} fieldKey="date">
-          <input type="date" value={date} onChange={(event) => setDate(event.target.value)} className={inputCls} />
+          <IsoDateInput value={date} onChange={(event) => setDate(event.target.value)} className={inputCls} />
         </Field>
       </div>
 

--- a/ui/src/pages/TextsPage.tsx
+++ b/ui/src/pages/TextsPage.tsx
@@ -8,6 +8,7 @@ import { CreateModalActions, EditModal, Field, TextArea, TextInput } from "../co
 import { ListPage, type DisplayMode } from "../components/ListPage";
 import { CardSelectionToggle, RouteCardLinkOverlay } from "../components/RouteCardLinkOverlay";
 import { CustomFieldsEditor } from "../components/shared";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { EntityReferencePopovers, TextTile } from "../components/EntityCards";
 import { useAuth } from "../auth/AuthContext";
 import { canWriteEntity } from "../auth/visibility";
@@ -314,7 +315,7 @@ function TextCreateModal({ open, onClose, onCreated }: { open: boolean; onClose:
 
       <div className="grid grid-cols-2 gap-4">
         <Field label="Title"><TextInput value={title} onChange={setTitle} placeholder="Text title" /></Field>
-        <Field label="Date"><input type="date" value={date} onChange={(event) => setDate(event.target.value)} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" /></Field>
+        <Field label="Date"><IsoDateInput value={date} onChange={(event) => setDate(event.target.value)} className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none" /></Field>
       </div>
       <Field label="Studio Code"><TextInput value={code} onChange={setCode} placeholder="Text code" /></Field>
       <Field label="Details"><TextArea value={details} onChange={setDetails} placeholder="Text notes" rows={3} /></Field>

--- a/ui/src/pages/VideoDetailPage.tsx
+++ b/ui/src/pages/VideoDetailPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useState, useRef, useEffect, useCallback, Fragment, useMemo, lazy, Suspense } from "react";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { IsoDateInput } from "../components/IsoDateInput";
 import type { Detection, Face, MetadataServer, PerformerSummary, ResolvedSpan, Video, VideoUpdate, Segment, TagApplication, TagProvenance } from "../api/types";
 import { ExtensionSlot } from "../router/RouteRegistry";
 import { AspectRatingsPanel } from "../components/AspectRatingsPanel";
@@ -43,6 +44,7 @@ import { MediaDetailLayout } from "../components/MediaDetailLayout/MediaDetailLa
 import { CoverImageDialog } from "../components/CoverImageDialog";
 import { PerformerTile, EntityRefBadge } from "../components/EntityCards";
 import { trackInteraction } from "../utils/interactionTracking";
+import { formatDateTime } from "../utils/dateFormat";
 import { getEditableTagIds, getLockedTagIds, mergeTagIds } from "../utils/tags";
 import { VideoVisualSimilarityPanel, useVideoVisualSimilarityAvailable } from "../components/VisualSimilarityPanel";
 import { VideoAudioSimilarityPanel, useVideoAudioSimilarityAvailable } from "../components/AudioSimilarityPanel";
@@ -529,13 +531,7 @@ export function VideoDetailPage({ id, initialSeekTo, onNavigate }: Props) {
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         {video.date ? (
           <FieldProvenanceHover fieldProvenance={video.fieldProvenance} fieldKey="date">
-            <span>
-              {new Date(`${video.date}T00:00:00`).toLocaleDateString(undefined, {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}
-            </span>
+            <span>{formatDate(video.date)}</span>
           </FieldProvenanceHover>
         ) : null}
 
@@ -1392,7 +1388,7 @@ function HistoryTab({
         {history?.playHistory && history.playHistory.length > 0 && (
           <div className="max-h-40 overflow-y-auto space-y-0.5 border-t border-border pt-2">
             {history.playHistory.map((date, i) => (
-              <div key={i} className="text-xs text-secondary">{new Date(date).toLocaleString()}</div>
+              <div key={i} className="text-xs text-secondary">{formatDateTime(date)}</div>
             ))}
           </div>
         )}
@@ -1418,7 +1414,7 @@ function HistoryTab({
                       <span>{session.intervals.length} intervals</span>
                     </div>
                   </div>
-                  <div className="shrink-0 text-xs text-secondary">{new Date(session.startedAt).toLocaleString()}</div>
+                  <div className="shrink-0 text-xs text-secondary">{formatDateTime(session.startedAt)}</div>
                 </div>
                 {session.intervals.length > 0 ? (
                   <div className="mt-2 flex flex-wrap gap-1.5">
@@ -2228,7 +2224,7 @@ function VideoEditPanel({ video, onSaved, onNavigate, onRequestReportTag }: { vi
           <label className="space-y-1"><span className="text-xs text-secondary">Title</span><input value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} /></label>
         </FieldProvenanceHover>
         <FieldProvenanceHover fieldProvenance={video.fieldProvenance} fieldKey="date" block>
-          <label className="space-y-1"><span className="text-xs text-secondary">Date</span><input type="date" value={date} onChange={(e) => setDate(e.target.value)} className={inputCls} /></label>
+          <label className="space-y-1"><span className="text-xs text-secondary">Date</span><IsoDateInput value={date} onChange={(e) => setDate(e.target.value)} className={inputCls} /></label>
         </FieldProvenanceHover>
       </div>
       <div className="grid grid-cols-2 gap-3">

--- a/ui/src/pages/VideoEditModal.tsx
+++ b/ui/src/pages/VideoEditModal.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { videos, tagApplications } from "../api/client";
 import type { Video, VideoUpdate, TagApplication } from "../api/types";
 import { EditModal, Field, TextInput, TextArea, SaveButton } from "../components/EditModal";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { RatingField } from "../components/Rating";
 import { CustomFieldsEditor, buildTagProvenanceById } from "../components/shared";
 import { StudioSelector } from "../components/StudioSelector";
@@ -129,8 +130,7 @@ export function VideoEditModal({ video, open, onClose }: Props) {
           <TextInput value={title} onChange={setTitle} placeholder="Video title" />
         </Field>
         <Field label="Date" fieldProvenance={video.fieldProvenance} fieldKey="date">
-          <input
-            type="date"
+          <IsoDateInput
             value={date}
             onChange={(e) => setDate(e.target.value)}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"
@@ -348,4 +348,3 @@ async function syncPerformerContextTags(videoId: number, existingApplications: T
     }
   }
 }
-

--- a/ui/src/pages/VideosPage.tsx
+++ b/ui/src/pages/VideosPage.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { entityEngagement, entityImages, videos } from "../api/client";
 import type { BoolCriterion, EntityEngagement, FindFilter, Group, Video, VideoCreate, VideoFilterCriteria, VideoListEntry } from "../api/types";
 import { ListPage, type DisplayMode } from "../components/ListPage";
+import { IsoDateInput } from "../components/IsoDateInput";
 import { EntityCardGrid } from "../components/EntityCardGrid";
 import { useListUrlState } from "../hooks/useListUrlState";
 import { usePaginatedInfiniteQuery } from "../hooks/usePaginatedInfiniteQuery";
@@ -1185,8 +1186,7 @@ function VideoCreateModal({ open, onClose, onCreated }: { open: boolean; onClose
           <TextInput value={title} onChange={setTitle} placeholder="Video title" />
         </Field>
         <Field label="Date">
-          <input
-            type="date"
+          <IsoDateInput
             value={date}
             onChange={(e) => setDate(e.target.value)}
             className="w-full bg-card border border-border rounded px-3 py-2 text-sm text-foreground focus:outline-none focus:border-accent"

--- a/ui/src/pages/settings/AdminSections.tsx
+++ b/ui/src/pages/settings/AdminSections.tsx
@@ -23,6 +23,7 @@ import { SettingsButton as Btn, SettingsField as Field, SettingsSection as Secti
 import { EditModal } from "../../components/EditModal";
 import { buildRoutePath } from "../../router/location";
 import { EntityReferenceSelector } from "../../components/EntityReferenceSelector";
+import { formatDateTime } from "../../utils/dateFormat";
 
 const ENTITY_KINDS = ["video", "performer", "tag", "studio", "gallery", "image", "group", "segment"] as const;
 const SCOPE_KINDS = ["all", "tag", "studio", "attribute", "expression"] as const;
@@ -408,7 +409,7 @@ export function UsersTab() {
                 <div className="mt-3 flex flex-wrap gap-1">
                   {userRow.roles.length ? userRow.roles.map((role) => <span key={role} className="rounded border border-border bg-surface px-2 py-0.5 text-xs">{role}</span>) : <span className="text-xs text-secondary">No roles</span>}
                 </div>
-                <div className="mt-3 text-xs text-secondary">Last login: {userRow.lastLoginAt ? new Date(userRow.lastLoginAt).toLocaleString() : "never"}</div>
+                <div className="mt-3 text-xs text-secondary">Last login: {userRow.lastLoginAt ? formatDateTime(userRow.lastLoginAt) : "never"}</div>
                 <div className="mt-3 flex flex-wrap gap-2">
                   {canWriteUsers ? <Btn onClick={() => setEditing(userRow)}>Edit</Btn> : null}
                   {canInviteUsers ? <Btn onClick={() => setInviteUser(userRow)}>{userRow.hasPassword ? "Reset password" : "Copy invite link"}</Btn> : null}
@@ -450,7 +451,7 @@ export function UsersTab() {
                     <td className="px-2 py-2">
                       <UserStatus user={u} />
                     </td>
-                    <td className="px-2 py-2 text-secondary">{u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleString() : "—"}</td>
+                    <td className="px-2 py-2 text-secondary">{u.lastLoginAt ? formatDateTime(u.lastLoginAt) : "—"}</td>
                     <td className="px-2 py-2">
                       <div className="flex flex-wrap justify-end gap-1">
                       {canWriteUsers ? <Btn onClick={() => setEditing(u)}>Edit</Btn> : null}
@@ -859,7 +860,7 @@ export function AuditTab() {
               <tbody>
                 {q.data.items.map((e) => (
                   <tr key={e.id} className="border-b border-border/40">
-                    <td className="px-2 py-2 whitespace-nowrap text-secondary">{new Date(e.occurredAt).toLocaleString()}</td>
+                    <td className="px-2 py-2 whitespace-nowrap text-secondary">{formatDateTime(e.occurredAt)}</td>
                     <td className="px-2 py-2">{e.actorUsername ?? <span className="text-secondary">{e.actorKind}</span>}</td>
                     <td className="px-2 py-2"><code className="text-xs">{e.action}</code></td>
                     <td className="px-2 py-2 text-secondary">{e.targetKind ? `${e.targetKind}:${e.targetId ?? ""}` : "—"}</td>
@@ -1028,7 +1029,7 @@ function ContentRuleTable({ rules, canWrite, onDelete }: { rules: ContentRuleRow
               </td>
               <td className="px-2 py-2 text-xs text-secondary">{formatContentRuleScope(rule)}</td>
               <td className="px-2 py-2">{rule.appliesTo}</td>
-              <td className="px-2 py-2 text-secondary">{new Date(rule.updatedAt).toLocaleString()}</td>
+              <td className="px-2 py-2 text-secondary">{formatDateTime(rule.updatedAt)}</td>
               <td className="px-2 py-2 text-right">
                 {canWrite ? <Btn variant="danger" onClick={() => { if (confirm("Delete this content rule?")) onDelete(rule.id); }}>Delete</Btn> : null}
               </td>
@@ -1070,7 +1071,7 @@ function EntityOverrideTable({ overrides, canWrite, onDelete }: { overrides: Ent
                 <span className={overrideItem.effect === "deny" ? "text-amber-400" : "text-emerald-400"}>{overrideItem.effect}</span>
               </td>
               <td className="px-2 py-2">{overrideItem.appliesTo}</td>
-              <td className="px-2 py-2 text-secondary">{new Date(overrideItem.createdAt).toLocaleString()}</td>
+              <td className="px-2 py-2 text-secondary">{formatDateTime(overrideItem.createdAt)}</td>
               <td className="px-2 py-2 text-right">
                 {canWrite ? <Btn variant="danger" onClick={() => { if (confirm("Delete this entity override?")) onDelete(overrideItem.id); }}>Delete</Btn> : null}
               </td>
@@ -1283,9 +1284,9 @@ function ApiTokensTable({ tokens, onRevoke }: { tokens: ApiTokenRow[]; onRevoke:
               <td className="px-2 py-2 font-medium">{token.name}</td>
               <td className="px-2 py-2 font-mono text-xs">{token.prefix}…</td>
               <td className="px-2 py-2 text-secondary">{token.scope?.length ? `${token.scope.length} perms` : "full"}</td>
-              <td className="px-2 py-2 text-secondary">{new Date(token.createdAt).toLocaleString()}</td>
-              <td className="px-2 py-2 text-secondary">{token.lastUsedAt ? new Date(token.lastUsedAt).toLocaleString() : "—"}</td>
-              <td className="px-2 py-2 text-secondary">{token.expiresAt ? new Date(token.expiresAt).toLocaleString() : "never"}</td>
+              <td className="px-2 py-2 text-secondary">{formatDateTime(token.createdAt)}</td>
+              <td className="px-2 py-2 text-secondary">{token.lastUsedAt ? formatDateTime(token.lastUsedAt) : "—"}</td>
+              <td className="px-2 py-2 text-secondary">{token.expiresAt ? formatDateTime(token.expiresAt) : "never"}</td>
               <td className="px-2 py-2 text-right">
                 <Btn variant="danger" onClick={() => { if (confirm(`Revoke token "${token.name}"?`)) onRevoke(token.id); }}>Revoke</Btn>
               </td>
@@ -1368,7 +1369,7 @@ function ShareLinksTable({ links, onRevoke }: { links: ShareLinkRow[]; onRevoke:
               <td className="px-2 py-2">{formatEntityKind(link.entityKind)}</td>
               <td className="px-2 py-2 text-secondary">{link.entityIds.length}</td>
               <td className="px-2 py-2 text-secondary">{link.viewCount}</td>
-              <td className="px-2 py-2 text-secondary">{link.expiresAt ? new Date(link.expiresAt).toLocaleString() : "never"}</td>
+              <td className="px-2 py-2 text-secondary">{link.expiresAt ? formatDateTime(link.expiresAt) : "never"}</td>
               <td className="px-2 py-2">
                 {link.revoked ? <span className="text-red-400">revoked</span> : link.hasPassword ? "password-gated" : "active"}
               </td>
@@ -1472,4 +1473,3 @@ function Modal({ title, onClose, children, wide }: { title: string; onClose: () 
     </EditModal>
   );
 }
-

--- a/ui/src/test/GalleryEditModal.test.tsx
+++ b/ui/src/test/GalleryEditModal.test.tsx
@@ -68,7 +68,7 @@ describe("GalleryEditModal", () => {
     vi.clearAllMocks();
   });
 
-  it("omits rating, organized, and videos while using a date input", async () => {
+  it("omits rating, organized, and videos while using an ISO date field", async () => {
     mockGalleries.update.mockResolvedValue({});
 
     renderModal();
@@ -79,7 +79,8 @@ describe("GalleryEditModal", () => {
     expect(screen.queryByText("video selector")).not.toBeInTheDocument();
 
     const dateInput = screen.getByDisplayValue("2026-05-01");
-    expect(dateInput).toHaveAttribute("type", "date");
+    expect(dateInput).toHaveAttribute("type", "text");
+    expect(dateInput).toHaveAttribute("placeholder", "yyyy-MM-dd");
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 

--- a/ui/src/test/IsoDateInput.test.tsx
+++ b/ui/src/test/IsoDateInput.test.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { IsoDateInput } from "../components/IsoDateInput";
+
+describe("IsoDateInput", () => {
+  it("shows the ISO value and provides a native calendar picker", () => {
+    const onChange = vi.fn();
+    const { container } = render(<IsoDateInput value="2026-05-01" onChange={onChange} />);
+
+    expect(screen.getByDisplayValue("2026-05-01")).toHaveAttribute("placeholder", "yyyy-MM-dd");
+    expect(screen.getByRole("button", { name: "Choose date" })).toBeInTheDocument();
+
+    const picker = container.querySelector('input[type="date"]');
+    expect(picker).not.toBeNull();
+    fireEvent.change(picker!, { target: { value: "2026-06-02" } });
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange.mock.calls[0][0].target.value).toBe("2026-06-02");
+  });
+});

--- a/ui/src/test/shared.test.ts
+++ b/ui/src/test/shared.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { formatDuration, formatFileSize, formatDate, getResolutionLabel } from "../components/shared";
+import { formatDateTime } from "../utils/dateFormat";
 
 describe("formatDuration", () => {
   it("returns 0:00 for zero seconds", () => {
@@ -70,14 +71,26 @@ describe("formatDate", () => {
     expect(formatDate("")).toBe("");
   });
 
-  it("formats a valid date string", () => {
-    const result = formatDate("2024-01-15");
-    expect(result).toBeTruthy();
-    expect(typeof result).toBe("string");
+  it("formats date-only values as yyyy-MM-dd", () => {
+    expect(formatDate("2024-01-15")).toBe("2024-01-15");
+  });
+
+  it("formats timestamps as yyyy-MM-dd", () => {
+    expect(formatDate("2024-01-15T23:30:00Z")).toBe("2024-01-15");
+  });
+
+  it("preserves the supplied calendar date when a timestamp has an offset", () => {
+    expect(formatDate("2024-01-15T23:30:00-05:00")).toBe("2024-01-15");
   });
 
   it("returns Invalid Date string for unparseable dates", () => {
     expect(formatDate("not-a-date")).toBe("Invalid Date");
+  });
+});
+
+describe("formatDateTime", () => {
+  it("formats timestamps consistently in UTC", () => {
+    expect(formatDateTime("2024-01-15T23:30:00-05:00")).toBe("2024-01-16 04:30:00 UTC");
   });
 });
 

--- a/ui/src/utils/dateFormat.ts
+++ b/ui/src/utils/dateFormat.ts
@@ -1,0 +1,13 @@
+export function formatDate(dateStr?: string): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "Invalid Date";
+  return dateStr.match(/^\d{4}-\d{2}-\d{2}/)?.[0] ?? date.toISOString().slice(0, 10);
+}
+
+export function formatDateTime(dateStr?: string): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "Invalid Date";
+  return `${date.toISOString().slice(0, 19).replace("T", " ")} UTC`;
+}


### PR DESCRIPTION
## Summary

Standardize date-only values across the UI as `yyyy-MM-dd` and timestamps as `yyyy-MM-dd HH:mm:ss UTC`.

This adds shared date formatting utilities and applies them to entity details/cards, provenance information, jobs, extension releases, playback/scrape history, and admin/security screens. Date and datetime editing now uses a reusable ISO input that keeps the app-controlled format visible while retaining a native calendar or date/time picker button, so users can either type or select a value.

This deliberately extends conventions already prevalent in Stash: its date editing, filtering, validation, and storage paths use ISO-oriented values such as `YYYY-MM-DD`, even though some read-only displays are localized. Using ISO consistently in Cove avoids mixing localized and non-localized representations across screens, removes ambiguous day/month ordering, and prevents browser locale differences while preserving the familiar calendar workflow.

## Linked issue

Closes #50
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [x] AI was used for this PR.
  - **Model(s):** GPT-5 Codex
  - **Where / how:** Issue analysis, live UI reproduction with Playwright, implementation, regression tests, build/test verification, and repeated xhigh diff reviews.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

Reproduced the issue in the live devbox by comparing the performer card and detail page for Sovereign Syre (`/performer/264`): the card showed `1986-07-04`, while the detail page showed the browser-localized `7/4/1986`.

After the fix:

- `/performer/264` displays the Born value as `1986-07-04`.
- The performer edit modal displays `1986-07-04` and exposes native calendar buttons for Birthdate, Death Date, Career Start, and Career End.
- Date and datetime locale conversions and native controls were audited across `ui/src`.

Commands run:

```bash
source gitignored/dev/agent.env
npm --prefix ui test
npm --prefix ui run build
npm --prefix ui test -- --run src/test/IsoDateInput.test.tsx src/test/GalleryEditModal.test.tsx src/test/FilterDialog.test.tsx
git diff --check
```

Results:

- Full UI suite: 54 test files passed, 281 tests passed.
- Final focused suite: 3 test files passed, 12 tests passed.
- Production UI build passed.
- `git diff --check` passed.
- Live UI verified with `playwright-cli`.

The production build continues to emit existing warnings about SignalR pure annotations, the generated Lucide default export, circular CustomFields re-exports, and large chunks.

Known non-blocking follow-up: manually typed date values currently rely on API/filter handling rather than strict client-side ISO validation. The native picker path supplies valid values.

## Checklist

- [X] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [x] Builds and existing tests pass.
- [x] I added or updated tests where it makes sense.
- [x] I updated docs where needed.
- [x] This PR is focused and does not bundle unrelated changes.