### PR TITLE
Fix media navigation across paginated lists

### DIFF
--- a/ui/src/components/Lightbox.tsx
+++ b/ui/src/components/Lightbox.tsx
@@ -40,6 +40,11 @@ export interface LightboxProps {
   slideshowDelay?: number;
   autoPlay?: boolean;
   canEngage?: boolean;
+  loadPrevious?: () => Promise<LightboxImage[]>;
+  loadNext?: () => Promise<LightboxImage[]>;
+  hasPrevious?: boolean;
+  hasNext?: boolean;
+  wrap?: boolean;
 }
 
 export function Lightbox({
@@ -50,7 +55,13 @@ export function Lightbox({
   slideshowDelay = 5000,
   autoPlay = false,
   canEngage = false,
+  loadPrevious,
+  loadNext,
+  hasPrevious = false,
+  hasNext = false,
+  wrap = true,
 }: LightboxProps) {
+  const [queuedImages, setQueuedImages] = useState(images);
   const [index, setIndex] = useState(initialIndex);
   const [loading, setLoading] = useState(true);
   const [playing, setPlaying] = useState(false);
@@ -59,6 +70,7 @@ export function Lightbox({
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [dragging, setDragging] = useState(false);
   const [fullscreen, setFullscreen] = useState(false);
+  const [boundaryLoading, setBoundaryLoading] = useState(false);
 
   const dragStart = useRef({ x: 0, y: 0 });
   const panStart = useRef({ x: 0, y: 0 });
@@ -71,8 +83,8 @@ export function Lightbox({
   const trackedOpen = useRef(false);
   const lastTrackedIndex = useRef<number | null>(null);
 
-  const count = images.length;
-  const current = images[index];
+  const count = queuedImages.length;
+  const current = queuedImages[index];
   const queryClient = useQueryClient();
   const { engagement, rating, setRating, ratingPending } = useEntityEngagement("image", current?.id ?? 0, { enabled: open && Boolean(current) });
   const likeMutation = useMutation({
@@ -110,6 +122,7 @@ export function Lightbox({
   // Sync index when initialIndex or open changes
   useEffect(() => {
     if (open) {
+      setQueuedImages(images);
       setIndex(initialIndex);
       setZoom(1);
       setPan({ x: 0, y: 0 });
@@ -227,8 +240,48 @@ export function Lightbox({
     [count, resetView],
   );
 
-  const goPrev = useCallback(() => goTo(index - 1), [goTo, index]);
-  const goNext = useCallback(() => goTo(index + 1), [goTo, index]);
+  const goPrev = useCallback(async () => {
+    if (index > 0 || !hasPrevious || !loadPrevious) {
+      if (index === 0 && !wrap) return;
+      goTo(index - 1);
+      return;
+    }
+    if (boundaryLoading) return;
+    setBoundaryLoading(true);
+    try {
+      const loaded = await loadPrevious();
+      if (loaded.length === 0) return;
+      setQueuedImages((currentImages) => [...loaded, ...currentImages]);
+      setIndex(loaded.length - 1);
+      setLoading(true);
+      resetView();
+    } catch {
+      // Keep the current image visible when an adjacent page cannot be loaded.
+    } finally {
+      setBoundaryLoading(false);
+    }
+  }, [boundaryLoading, goTo, hasPrevious, index, loadPrevious, resetView, wrap]);
+  const goNext = useCallback(async () => {
+    if (index < count - 1 || !hasNext || !loadNext) {
+      if (index === count - 1 && !wrap) return;
+      goTo(index + 1);
+      return;
+    }
+    if (boundaryLoading) return;
+    setBoundaryLoading(true);
+    try {
+      const loaded = await loadNext();
+      if (loaded.length === 0) return;
+      setQueuedImages((currentImages) => [...currentImages, ...loaded]);
+      setIndex(index + 1);
+      setLoading(true);
+      resetView();
+    } catch {
+      // Keep the current image visible when an adjacent page cannot be loaded.
+    } finally {
+      setBoundaryLoading(false);
+    }
+  }, [boundaryLoading, count, goTo, hasNext, index, loadNext, resetView, wrap]);
 
   const toggleSlideshow = useCallback(() => setPlaying((p) => !p), []);
 
@@ -388,11 +441,11 @@ export function Lightbox({
     if (!open || count <= 1) return;
     const preload = (i: number) => {
       const img = new Image();
-      img.src = images[((i % count) + count) % count].src;
+      img.src = queuedImages[((i % count) + count) % count]?.src ?? "";
     };
     preload(index + 1);
     preload(index - 1);
-  }, [open, index, images, count]);
+  }, [open, index, queuedImages, count]);
 
   if (!open) return <></>;
 
@@ -483,9 +536,10 @@ export function Lightbox({
       </div>
 
       {/* Previous button */}
-      {count > 1 && (
+      {(count > 1 || hasPrevious) && (
         <button
           onClick={goPrev}
+          disabled={boundaryLoading || (!wrap && index === 0 && !hasPrevious)}
           className="absolute left-4 top-1/2 -translate-y-1/2 z-10 p-2 text-white/80 hover:text-white rounded-full hover:bg-white/10 transition-colors"
           aria-label="Previous image"
         >
@@ -494,9 +548,10 @@ export function Lightbox({
       )}
 
       {/* Next button */}
-      {count > 1 && (
+      {(count > 1 || hasNext) && (
         <button
           onClick={goNext}
+          disabled={boundaryLoading || (!wrap && index === count - 1 && !hasNext)}
           className="absolute right-4 top-1/2 -translate-y-1/2 z-10 p-2 text-white/80 hover:text-white rounded-full hover:bg-white/10 transition-colors"
           aria-label="Next image"
         >

--- a/ui/src/pages/GalleryDetailPage.tsx
+++ b/ui/src/pages/GalleryDetailPage.tsx
@@ -3,12 +3,13 @@ import { galleries, images, videos, fileOps } from "../api/client";
 import type { FindFilter, Gallery, Image, ImageFilterCriteria, Video, VideoFilterCriteria } from "../api/types";
 import { formatDate, formatDuration, formatFileSize, getResolutionLabel, TagBadge, CustomFieldsDisplay, FieldProvenanceHover, resolveTagProvenance } from "../components/shared";
 import { Film, FolderOpen, HardDrive, ImageIcon, Link as LinkIcon, Pencil, Plus, Trash2, Loader2, MoreVertical, RefreshCw, Star } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GalleryEditModal } from "./GalleryEditModal";
 import { ConfirmDialog } from "../components/ConfirmDialog";
 import { DetailSkeleton } from "../components/DetailSkeleton";
 import { ExtensionSlot } from "../router/RouteRegistry";
 import { Lightbox, type LightboxImage } from "../components/Lightbox";
+import { extendLightboxPageBounds } from "../utils/lightboxPagination";
 import { InteractiveRating } from "../components/Rating";
 import { DetailListToolbar } from "../components/DetailListToolbar";
 import { IMAGE_CRITERIA, VIDEO_CRITERIA } from "../components/FilterDialog";
@@ -58,15 +59,16 @@ export function GalleryDetailPage({ id, onNavigate }: Props) {
     queryKey: ["gallery", id],
     queryFn: () => galleries.get(id),
   });
+  const queryGalleryImages = useCallback((nextFilter: FindFilter) => hasImageObjectFilter
+    ? images.findFiltered({
+        findFilter: nextFilter,
+        objectFilter: withRequiredMultiId(imageObjectFilter as ImageFilterCriteria, "galleriesCriterion", id),
+      })
+    : images.find(nextFilter, { galleryId: id }), [hasImageObjectFilter, id, imageObjectFilter]);
   const { data: galleryImages, infinitePageSize: imageInfinitePageSize, infiniteQuery: imageInfiniteQuery, infiniteFilterKey: imageInfiniteFilterKey, fetchAllIds: fetchAllImageIds, loadMore: loadMoreImages } = useDetailListQuery<Image>({
     queryKey: ["gallery-images", id, imageObjectFilter],
     filter: imageFilter,
-    queryFn: (nextFilter) => hasImageObjectFilter
-      ? images.findFiltered({
-          findFilter: nextFilter,
-          objectFilter: withRequiredMultiId(imageObjectFilter as ImageFilterCriteria, "galleriesCriterion", id),
-        })
-      : images.find(nextFilter, { galleryId: id }),
+    queryFn: queryGalleryImages,
     enabled: !!gallery,
   });
   const effectiveImageCount = galleryImages?.totalCount ?? gallery?.imageCount ?? 0;
@@ -80,6 +82,7 @@ export function GalleryDetailPage({ id, onNavigate }: Props) {
   ]);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
+  const [lightboxPageBounds, setLightboxPageBounds] = useState(() => ({ first: imageFilter.page ?? 1, last: imageFilter.page ?? 1 }));
   const [imageZoom, setImageZoom] = useState(0);
   const [videoFilter, setVideoFilter] = useState<FindFilter>({ page: 1, perPage: 24, direction: "desc" });
   const [showAddImages, setShowAddImages] = useState(false);
@@ -224,6 +227,20 @@ export function GalleryDetailPage({ id, onNavigate }: Props) {
     [galleryImages, id],
   );
 
+  const openGalleryLightbox = useCallback((imageId: number) => {
+    const visibleImages = galleryImages?.items ?? [];
+    const page = imageFilter.page ?? 1;
+    setLightboxPageBounds({ first: page, last: page });
+    setLightboxIndex(Math.max(0, visibleImages.findIndex((image) => image.id === imageId)));
+    setLightboxOpen(true);
+  }, [galleryImages, imageFilter.page]);
+
+  const loadGalleryLightboxPage = useCallback(async (page: number, direction: "previous" | "next") => {
+    const response = await queryGalleryImages({ ...imageFilter, page });
+    setLightboxPageBounds((bounds) => extendLightboxPageBounds(bounds, page, direction));
+    return response.items.map((img) => ({ id: img.id, src: images.imageUrl(img.id), title: img.title, interactionSource: "galleryDetailPage", interactionMeta: { galleryId: id } }));
+  }, [id, imageFilter, queryGalleryImages]);
+
   if (isLoading) {
     return (
       <div className="px-1 py-2">
@@ -255,7 +272,7 @@ export function GalleryDetailPage({ id, onNavigate }: Props) {
               fetchAllIds={fetchAllImageIds}
               loadMore={loadMoreImages}
             onShowAddImages={() => setShowAddImages(true)}
-            onLightbox={(idx) => { setLightboxIndex(idx); setLightboxOpen(true); }}
+            onLightbox={openGalleryLightbox}
             imageZoom={imageZoom}
             setImageZoom={setImageZoom}
             canWriteGallery={canWriteGallery}
@@ -427,6 +444,11 @@ export function GalleryDetailPage({ id, onNavigate }: Props) {
         open={lightboxOpen}
         onClose={() => setLightboxOpen(false)}
         canEngage={canEngageImages}
+        hasPrevious={!imageInfinitePageSize && lightboxPageBounds.first > 1}
+        hasNext={!imageInfinitePageSize && lightboxPageBounds.last * (imageFilter.perPage ?? 60) < (galleryImages?.totalCount ?? 0)}
+        loadPrevious={() => loadGalleryLightboxPage(lightboxPageBounds.first - 1, "previous")}
+        loadNext={() => loadGalleryLightboxPage(lightboxPageBounds.last + 1, "next")}
+        wrap={imageInfinitePageSize}
       />
     </div>
   );
@@ -513,7 +535,7 @@ function GalleryImagesPanel({ galleryId, filter, setFilter, objectFilter, setObj
   fetchAllIds: () => Promise<Array<Image["id"]>>;
   loadMore: () => void;
   onShowAddImages: () => void;
-  onLightbox: (idx: number) => void;
+  onLightbox: (imageId: number) => void;
   imageZoom: number;
   setImageZoom: (z: number) => void;
   canWriteGallery: boolean;
@@ -572,7 +594,7 @@ function GalleryImagesPanel({ galleryId, filter, setFilter, objectFilter, setObj
           <Plus className="w-3 h-3" /> Add Images
         </button>
       </div> : null}
-      <RelatedEntityListView entityType="images" items={items} displayMode={displayMode} zoomLevel={imageZoom} selectedIds={selectedIds} selecting={selecting} onToggle={toggle} onNavigate={onNavigate} onImageQuickView={setQuickViewId} onImagePreview={(_image, index) => onLightbox(index)} onImageDetails={(image) => onNavigate({ page: "image", id: image.id })} infinitePageSize={infinitePageSize} hasNextPage={infiniteQuery.hasNextPage} isFetchingNextPage={infiniteQuery.isFetchingNextPage} loadMore={loadMore} />
+      <RelatedEntityListView entityType="images" items={items} displayMode={displayMode} zoomLevel={imageZoom} selectedIds={selectedIds} selecting={selecting} onToggle={toggle} onNavigate={onNavigate} onImageQuickView={setQuickViewId} onImagePreview={(image) => onLightbox(image.id)} onImageDetails={(image) => onNavigate({ page: "image", id: image.id })} infinitePageSize={infinitePageSize} hasNextPage={infiniteQuery.hasNextPage} isFetchingNextPage={infiniteQuery.isFetchingNextPage} loadMore={loadMore} />
       {quickViewId !== null && (
         <QuickViewDialog type="image" id={quickViewId} onClose={() => setQuickViewId(null)} onNavigate={onNavigate} />
       )}

--- a/ui/src/pages/ImagesPage.tsx
+++ b/ui/src/pages/ImagesPage.tsx
@@ -13,6 +13,7 @@ import { IMAGE_CRITERIA } from "../components/FilterDialog";
 import { BulkEditDialog, IMAGE_BULK_FIELDS } from "../components/BulkEditDialog";
 import { ImageTile } from "../components/EntityCards";
 import type { LightboxImage } from "../components/Lightbox";
+import { extendLightboxPageBounds } from "../utils/lightboxPagination";
 import { getDefaultFilter } from "../components/SavedFilterMenu";
 import { CardSelectionToggle, RouteCardLinkOverlay } from "../components/RouteCardLinkOverlay";
 import { useAuth } from "../auth/AuthContext";
@@ -74,6 +75,7 @@ export function ImagesPage({ onNavigate }: Props) {
   const [lightboxIndex, setLightboxIndex] = useState(0);
   const [lightboxAutoPlay, setLightboxAutoPlay] = useState(false);
   const [lightboxScopeIds, setLightboxScopeIds] = useState<Set<number> | null>(null);
+  const [lightboxPageBounds, setLightboxPageBounds] = useState(() => ({ first: filter.page ?? 1, last: filter.page ?? 1 }));
   const [quickViewId, setQuickViewId] = useState<number | null>(null);
   const [wallColumnCount, setWallColumnCount] = useState(6);
   const lastPagedFilterRef = useRef<Pick<FindFilter, "page" | "perPage">>({ page: defaultState.filter.page ?? 1, perPage: defaultState.filter.perPage });
@@ -156,22 +158,23 @@ export function ImagesPage({ onNavigate }: Props) {
     }
   }, [defaultState.filter.perPage, filter, setDisplayMode, setFilter]);
 
+  const queryImagesPage = useCallback((nextFilter: FindFilter) => {
+    if (visualSearchActive) {
+      return visualSimilarity.searchImages({
+        findFilter: nextFilter,
+        objectFilter: hasObjectFilter ? objectFilter as ImageFilterCriteria : undefined,
+      });
+    }
+    return hasObjectFilter
+      ? images.findFiltered({ findFilter: nextFilter, objectFilter: objectFilter as ImageFilterCriteria })
+      : images.find(nextFilter);
+  }, [hasObjectFilter, objectFilter, visualSearchActive, visualSimilarity]);
+
   const listData = useInfiniteListData<Image>({
     queryKey: ["images", objectFilter, searchMode],
     filter,
     chunkSize: infiniteChunkSize,
-    queryPage: (nextFilter) => {
-      if (visualSearchActive) {
-        return visualSimilarity.searchImages({
-          findFilter: nextFilter,
-          objectFilter: hasObjectFilter ? objectFilter as ImageFilterCriteria : undefined,
-        });
-      }
-
-      return hasObjectFilter
-        ? images.findFiltered({ findFilter: nextFilter, objectFilter: objectFilter as ImageFilterCriteria })
-        : images.find(nextFilter);
-    },
+    queryPage: queryImagesPage,
   });
 
   const items = listData.items;
@@ -210,6 +213,21 @@ export function ImagesPage({ onNavigate }: Props) {
     setLightboxAutoPlay(false);
     setLightboxScopeIds(null);
   }, []);
+
+  const openListLightbox = useCallback((imageId: number) => {
+    setLightboxScopeIds(null);
+    const page = filter.page ?? 1;
+    setLightboxPageBounds({ first: page, last: page });
+    setLightboxAutoPlay(false);
+    setLightboxIndex(Math.max(0, items.findIndex((item) => item.id === imageId)));
+    setLightboxOpen(true);
+  }, [filter.page, items]);
+
+  const loadLightboxPage = useCallback(async (page: number, direction: "previous" | "next") => {
+    const response = await queryImagesPage({ ...filter, page });
+    setLightboxPageBounds((bounds) => extendLightboxPageBounds(bounds, page, direction));
+    return response.items.map((img) => ({ id: img.id, src: images.imageUrl(img.id), title: getImageDisplayTitle(img), interactionSource: "imagesPage", interactionMeta: { pageKey: "images" } }));
+  }, [filter, queryImagesPage]);
 
   const playSelectedImages = useCallback(() => {
     if (selectedVisibleImages.length === 0) {
@@ -397,7 +415,7 @@ export function ImagesPage({ onNavigate }: Props) {
           hasNextPage={listData.infiniteQuery.hasNextPage}
           isFetchingNextPage={listData.infiniteQuery.isFetchingNextPage}
           loadMore={listData.loadMore}
-          renderItem={(img, idx) => (
+          renderItem={(img) => (
             <ImageTile
               image={img}
               engagement={engagementById.get(img.id)}
@@ -407,10 +425,7 @@ export function ImagesPage({ onNavigate }: Props) {
               }}
               onPreview={(toggleOptions) => {
                 if (selecting) { toggle(img.id, toggleOptions); return; }
-                setLightboxScopeIds(null);
-                setLightboxAutoPlay(false);
-                setLightboxIndex(idx);
-                setLightboxOpen(true);
+                openListLightbox(img.id);
               }}
               onDetails={() => {
                 if (selecting) { toggle(img.id); return; }
@@ -465,6 +480,11 @@ export function ImagesPage({ onNavigate }: Props) {
           slideshowDelay={config?.ui.slideshowDelay}
           autoPlay={lightboxAutoPlay}
           canEngage={canEngageImage}
+          hasPrevious={!lightboxScopeIds && !infinitePageSize && lightboxPageBounds.first > 1}
+          hasNext={!lightboxScopeIds && !infinitePageSize && lightboxPageBounds.last * (filter.perPage ?? 40) < totalCount}
+          loadPrevious={() => loadLightboxPage(lightboxPageBounds.first - 1, "previous")}
+          loadNext={() => loadLightboxPage(lightboxPageBounds.last + 1, "next")}
+          wrap={lightboxScopeIds !== null || infinitePageSize}
         />
       ) : null}
       {quickViewId !== null ? (

--- a/ui/src/pages/VideoDetailPage.tsx
+++ b/ui/src/pages/VideoDetailPage.tsx
@@ -174,7 +174,7 @@ export function VideoDetailPage({ id, initialSeekTo, onNavigate }: Props) {
   });
   const { hasPermission, user } = useAuth();
   const { config } = useAppConfig();
-  const { queue, currentId: queueCurrentId, hasPrev, hasNext, prevId, nextId, currentPosition, queueLength, queueItems, goToIndex, clearQueue, autoplay: queueAutoplay, toggleAutoplay } = useVideoQueue();
+  const { queue, currentId: queueCurrentId, hasPrev, hasNext, currentPosition, queueLength, queueItems, goToIndex, goPrevious, goNext, clearQueue, autoplay: queueAutoplay, toggleAutoplay } = useVideoQueue();
   const { getTabsForPage, resolveComponent: resolveExtComponent, getFeature } = useExtensions();
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [showGenerate, setShowGenerate] = useState(false);
@@ -478,6 +478,14 @@ export function VideoDetailPage({ id, initialSeekTo, onNavigate }: Props) {
   }, [goToIndex, id, queue, queueCurrentId]);
 
   const queueSyncedToVideo = queueCurrentId === id;
+  const navigatePreviousVideo = useCallback(async () => {
+    const targetId = await goPrevious();
+    if (targetId != null) onNavigate({ page: "video", id: targetId });
+  }, [goPrevious, onNavigate]);
+  const navigateNextVideo = useCallback(async () => {
+    const targetId = await goNext();
+    if (targetId != null) onNavigate({ page: "video", id: targetId });
+  }, [goNext, onNavigate]);
 
   const videoKeyboardShortcuts = useMemo(() => [
     { key: "a", description: "Open details tab", handler: () => setActiveTab("details") },
@@ -486,9 +494,9 @@ export function VideoDetailPage({ id, initialSeekTo, onNavigate }: Props) {
     { key: "i", description: "Open file info tab", handler: () => canReadFiles && setActiveTab("file-info") },
     { key: "h", description: "Open history tab", handler: () => setActiveTab("history") },
     { key: "o", description: "Toggle favorite", handler: () => video && canEngageVideo && setVideoFavorite(!videoFavorite) },
-    { key: "[", description: "Open previous video", handler: () => queueSyncedToVideo && hasPrev && prevId != null && onNavigate({ page: "video", id: prevId }) },
-    { key: "]", description: "Open next video", handler: () => queueSyncedToVideo && hasNext && nextId != null && onNavigate({ page: "video", id: nextId }) },
-  ], [canEngageVideo, canReadFiles, canReadSegments, canWriteVideo, hasNext, hasPrev, nextId, onNavigate, prevId, queueSyncedToVideo, video, videoFavorite, setVideoFavorite]);
+    { key: "[", description: "Open previous video", handler: () => { if (queueSyncedToVideo && hasPrev) void navigatePreviousVideo(); } },
+    { key: "]", description: "Open next video", handler: () => { if (queueSyncedToVideo && hasNext) void navigateNextVideo(); } },
+  ], [canEngageVideo, canReadFiles, canReadSegments, canWriteVideo, hasNext, hasPrev, navigateNextVideo, navigatePreviousVideo, queueSyncedToVideo, video, videoFavorite, setVideoFavorite]);
 
   if (isLoading) {
     return (
@@ -725,9 +733,9 @@ export function VideoDetailPage({ id, initialSeekTo, onNavigate }: Props) {
             autostart={config?.ui.autostartVideo}
             showAbLoop={config?.ui.showAbLoopControls}
             trackingEnabled={trackPlaybackActivity}
-            onEnded={() => { if (queueAutoplay && queueSyncedToVideo && hasNext && nextId != null) onNavigate({ page: "video", id: nextId }); }}
-            onPrev={queueSyncedToVideo && hasPrev && prevId != null ? () => onNavigate({ page: "video", id: prevId }) : undefined}
-            onNext={queueSyncedToVideo && hasNext && nextId != null ? () => onNavigate({ page: "video", id: nextId }) : undefined}
+            onEnded={() => { if (queueAutoplay && queueSyncedToVideo && hasNext) void navigateNextVideo(); }}
+            onPrev={queueSyncedToVideo && hasPrev ? () => { void navigatePreviousVideo(); } : undefined}
+            onNext={queueSyncedToVideo && hasNext ? () => { void navigateNextVideo(); } : undefined}
           />
         ) : (
           <div className="flex h-48 items-center justify-center text-muted">No video file available</div>

--- a/ui/src/pages/VideosPage.tsx
+++ b/ui/src/pages/VideosPage.tsx
@@ -488,16 +488,54 @@ export function VideosPage({ onNavigate }: Props) {
 
   const navigateToVideo = useCallback((videoId: number) => {
     const ids = items.map((s) => s.id);
+    const queueItems = items.map((video) => ({
+      id: video.id,
+      title: video.title || video.files[0]?.basename || `Video ${video.id}`,
+      subtitle: video.studioName || video.date || undefined,
+      imagePath: videos.screenshotUrl(video.id, video.updatedAt),
+    }));
     if (ids.length > 0) {
-      setQueue(ids, videoId, items.map((video) => ({
+      const queryPage = (nextFilter: FindFilter) => {
+        if (visualSearchActive) {
+          return visualSimilarity.searchVideos({
+            findFilter: nextFilter,
+            objectFilter: hasObjectFilter ? backendObjectFilter as VideoFilterCriteria : undefined,
+          });
+        }
+
+        return hasObjectFilter
+          ? videos.findFiltered({ findFilter: nextFilter, objectFilter: backendObjectFilter as VideoFilterCriteria })
+          : videos.find(nextFilter);
+      };
+      const toQueueItems = (pageItems: Video[]) => pageItems.map((video) => ({
         id: video.id,
         title: video.title || video.files[0]?.basename || `Video ${video.id}`,
         subtitle: video.studioName || video.date || undefined,
         imagePath: videos.screenshotUrl(video.id, video.updatedAt),
-      })));
+      }));
+      const pageSize = filter.perPage ?? 40;
+      let firstPage = filter.page ?? 1;
+      let lastPage = firstPage;
+      const count = totalCount ?? ids.length;
+      setQueue(ids, videoId, queueItems, !infinitePageSize ? {
+        startIndex: (firstPage - 1) * pageSize,
+        totalCount: count,
+        loadPrevious: firstPage > 1 ? async () => {
+          const page = firstPage - 1;
+          const response = await queryPage({ ...filter, page });
+          firstPage = page;
+          return { items: toQueueItems(response.items), hasMore: page > 1 };
+        } : undefined,
+        loadNext: lastPage * pageSize < count ? async () => {
+          const page = lastPage + 1;
+          const response = await queryPage({ ...filter, page });
+          lastPage = page;
+          return { items: toQueueItems(response.items), hasMore: page * pageSize < response.totalCount };
+        } : undefined,
+      } : undefined);
     }
     onNavigate({ page: "video", id: videoId });
-  }, [items, setQueue, onNavigate]);
+  }, [backendObjectFilter, filter, hasObjectFilter, infinitePageSize, items, onNavigate, setQueue, totalCount, visualSearchActive, visualSimilarity]);
 
   const handlePlaySelected = useCallback(() => {
     const selectedVideos = items.filter((video) => selectedIds.has(video.id));

--- a/ui/src/state/VideoQueueContext.tsx
+++ b/ui/src/state/VideoQueueContext.tsx
@@ -1,10 +1,14 @@
-import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from "react";
 
 interface VideoQueueState {
   videoIds: number[];
   currentIndex: number;
   autoplay: boolean;
   items?: Record<number, VideoQueueItem>;
+  startIndex?: number;
+  totalCount?: number;
+  hasRemotePrevious?: boolean;
+  hasRemoteNext?: boolean;
 }
 
 // Persist the queue per-tab so a refresh or back/forward navigation doesn't lose it. sessionStorage
@@ -18,7 +22,15 @@ function readStoredQueue(): VideoQueueState | null {
     if (!raw) return null;
     const parsed = JSON.parse(raw);
     if (!parsed || !Array.isArray(parsed.videoIds) || typeof parsed.currentIndex !== "number") return null;
-    return parsed as VideoQueueState;
+    // Page loaders are functions and intentionally cannot be persisted. A restored queue remains
+    // usable for its already-loaded items without exposing boundary controls that cannot load.
+    return {
+      ...parsed,
+      startIndex: 0,
+      totalCount: parsed.videoIds.length,
+      hasRemotePrevious: false,
+      hasRemoteNext: false,
+    } as VideoQueueState;
   } catch {
     return null;
   }
@@ -31,9 +43,17 @@ export interface VideoQueueItem {
   imagePath?: string | null;
 }
 
+interface VideoQueuePageResult { items: VideoQueueItem[]; hasMore: boolean }
+interface VideoQueueOptions {
+  startIndex: number;
+  totalCount: number;
+  loadPrevious?: () => Promise<VideoQueuePageResult>;
+  loadNext?: () => Promise<VideoQueuePageResult>;
+}
+
 interface VideoQueueContextValue {
   queue: VideoQueueState | null;
-  setQueue: (ids: number[], currentId: number, items?: VideoQueueItem[]) => void;
+  setQueue: (ids: number[], currentId: number, items?: VideoQueueItem[], options?: VideoQueueOptions) => void;
   clearQueue: () => void;
   currentId: number | null;
   prevId: number | null;
@@ -41,6 +61,8 @@ interface VideoQueueContextValue {
   hasPrev: boolean;
   hasNext: boolean;
   goToIndex: (index: number) => number | null;
+  goPrevious: () => Promise<number | null>;
+  goNext: () => Promise<number | null>;
   toggleAutoplay: () => void;
   autoplay: boolean;
   queueLength: number;
@@ -52,6 +74,9 @@ const VideoQueueContext = createContext<VideoQueueContextValue | null>(null);
 
 export function VideoQueueProvider({ children }: { children: ReactNode }) {
   const [queue, setQueueState] = useState<VideoQueueState | null>(() => readStoredQueue());
+  const loadersRef = useRef<Pick<VideoQueueOptions, "loadPrevious" | "loadNext">>({});
+  const loadingBoundaryRef = useRef(false);
+  const queueGenerationRef = useRef(0);
 
   useEffect(() => {
     try {
@@ -62,16 +87,31 @@ export function VideoQueueProvider({ children }: { children: ReactNode }) {
     }
   }, [queue]);
 
-  const setQueue = useCallback((ids: number[], currentId: number, items?: VideoQueueItem[]) => {
+  const setQueue = useCallback((ids: number[], currentId: number, items?: VideoQueueItem[], options?: VideoQueueOptions) => {
+    queueGenerationRef.current += 1;
     const idx = ids.indexOf(currentId);
     const itemMap = items?.reduce<Record<number, VideoQueueItem>>((map, item) => {
       map[item.id] = item;
       return map;
     }, {});
-    setQueueState({ videoIds: ids, currentIndex: idx >= 0 ? idx : 0, autoplay: false, items: itemMap });
+    loadersRef.current = { loadPrevious: options?.loadPrevious, loadNext: options?.loadNext };
+    setQueueState({
+      videoIds: ids,
+      currentIndex: idx >= 0 ? idx : 0,
+      autoplay: false,
+      items: itemMap,
+      startIndex: options?.startIndex ?? 0,
+      totalCount: options?.totalCount ?? ids.length,
+      hasRemotePrevious: Boolean(options?.loadPrevious),
+      hasRemoteNext: Boolean(options?.loadNext),
+    });
   }, []);
 
-  const clearQueue = useCallback(() => setQueueState(null), []);
+  const clearQueue = useCallback(() => {
+    queueGenerationRef.current += 1;
+    loadersRef.current = {};
+    setQueueState(null);
+  }, []);
 
   const currentId = queue ? queue.videoIds[queue.currentIndex] ?? null : null;
   const prevId = queue && queue.currentIndex > 0 ? queue.videoIds[queue.currentIndex - 1] : null;
@@ -82,10 +122,50 @@ export function VideoQueueProvider({ children }: { children: ReactNode }) {
 
   const goToIndex = useCallback((index: number) => {
     if (!queue || index < 0 || index >= queue.videoIds.length) return null;
+    queueGenerationRef.current += 1;
     const id = queue.videoIds[index];
     setQueueState({ ...queue, currentIndex: index });
     return id;
   }, [queue]);
+
+  const loadBoundary = useCallback(async (direction: "previous" | "next") => {
+    if (loadingBoundaryRef.current) return null;
+    const loader = direction === "previous" ? loadersRef.current.loadPrevious : loadersRef.current.loadNext;
+    if (!loader) return null;
+    const generation = queueGenerationRef.current;
+    loadingBoundaryRef.current = true;
+    try {
+      const result = await loader();
+      if (queueGenerationRef.current !== generation) return null;
+      if (result.items.length === 0) return null;
+      const ids = result.items.map((item) => item.id);
+      const itemMap = Object.fromEntries(result.items.map((item) => [item.id, item]));
+      const targetId = direction === "previous" ? ids.at(-1) ?? null : ids[0] ?? null;
+      setQueueState((current) => {
+        if (!current) return current;
+        if (direction === "previous") {
+          if (!result.hasMore) loadersRef.current.loadPrevious = undefined;
+          return { ...current, videoIds: [...ids, ...current.videoIds], currentIndex: ids.length - 1, startIndex: Math.max(0, (current.startIndex ?? 0) - ids.length), items: { ...current.items, ...itemMap }, hasRemotePrevious: result.hasMore };
+        }
+        if (!result.hasMore) loadersRef.current.loadNext = undefined;
+        return { ...current, videoIds: [...current.videoIds, ...ids], currentIndex: current.videoIds.length, items: { ...current.items, ...itemMap }, hasRemoteNext: result.hasMore };
+      });
+      return targetId;
+    } catch {
+      return null;
+    } finally {
+      loadingBoundaryRef.current = false;
+    }
+  }, []);
+
+  const goPrevious = useCallback(async () => {
+    if (prevId != null && queue) return goToIndex(queue.currentIndex - 1);
+    return loadBoundary("previous");
+  }, [goToIndex, loadBoundary, prevId, queue]);
+  const goNext = useCallback(async () => {
+    if (nextId != null && queue) return goToIndex(queue.currentIndex + 1);
+    return loadBoundary("next");
+  }, [goToIndex, loadBoundary, nextId, queue]);
 
   const toggleAutoplay = useCallback(() => {
     setQueueState((prev) => prev ? { ...prev, autoplay: !prev.autoplay } : null);
@@ -100,13 +180,15 @@ export function VideoQueueProvider({ children }: { children: ReactNode }) {
         currentId,
         prevId,
         nextId,
-        hasPrev: prevId !== null,
-        hasNext: nextId !== null,
+        hasPrev: prevId !== null || Boolean(queue?.hasRemotePrevious),
+        hasNext: nextId !== null || Boolean(queue?.hasRemoteNext),
         goToIndex,
+        goPrevious,
+        goNext,
         toggleAutoplay,
         autoplay: queue?.autoplay ?? false,
-        queueLength: queue?.videoIds.length ?? 0,
-        currentPosition: queue ? queue.currentIndex + 1 : 0,
+        queueLength: queue?.totalCount ?? queue?.videoIds.length ?? 0,
+        currentPosition: queue ? (queue.startIndex ?? 0) + queue.currentIndex + 1 : 0,
         queueItems,
       }}
     >
@@ -120,4 +202,3 @@ export function useVideoQueue() {
   if (!ctx) throw new Error("useVideoQueue must be used within VideoQueueProvider");
   return ctx;
 }
-

--- a/ui/src/test/LightboxPagination.test.tsx
+++ b/ui/src/test/LightboxPagination.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { Lightbox } from "../components/Lightbox";
+import { extendLightboxPageBounds } from "../utils/lightboxPagination";
+
+vi.mock("../api/client", () => ({
+  entityEngagement: { get: vi.fn().mockResolvedValue(undefined) },
+  images: { incrementLike: vi.fn().mockResolvedValue(0) },
+  playback: { recordIntervals: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("../utils/interactionTracking", () => ({
+  createPlaybackSessionId: () => "test-session",
+  trackInteraction: vi.fn(),
+}));
+
+vi.mock("../components/Rating", () => ({
+  InteractiveRating: () => null,
+}));
+
+describe("Lightbox pagination", () => {
+  it("tracks both loaded boundaries when navigation reverses direction", () => {
+    let bounds = { first: 5, last: 5 };
+    bounds = extendLightboxPageBounds(bounds, 6, "next");
+    bounds = extendLightboxPageBounds(bounds, 4, "previous");
+    bounds = extendLightboxPageBounds(bounds, 7, "next");
+
+    expect(bounds).toEqual({ first: 4, last: 7 });
+  });
+
+  it("loads and advances to the next page at the queue boundary", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const loadNext = vi.fn().mockResolvedValue([
+      { id: 2, src: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", title: "Page two image" },
+    ]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Lightbox
+          images={[{ id: 1, src: "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==", title: "Page one image" }]}
+          initialIndex={0}
+          open
+          onClose={() => {}}
+          hasNext
+          loadNext={loadNext}
+        />
+      </QueryClientProvider>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Next image" }));
+
+    await waitFor(() => expect(screen.getByAltText("Page two image")).toBeInTheDocument());
+    expect(loadNext).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/test/videoQueue.test.tsx
+++ b/ui/src/test/videoQueue.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { VideoQueueProvider, useVideoQueue } from "../state/VideoQueueContext";
+
+describe("video queues", () => {
+  it("loads the next page at the queue boundary", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => <VideoQueueProvider>{children}</VideoQueueProvider>;
+    const { result } = renderHook(() => useVideoQueue(), { wrapper });
+    const loadNext = vi.fn().mockResolvedValue({ items: [{ id: 30 }, { id: 40 }], hasMore: false });
+
+    act(() => result.current.setQueue([10, 20], 20, undefined, { startIndex: 0, totalCount: 4, loadNext }));
+    let targetId: number | null = null;
+    await act(async () => { targetId = await result.current.goNext(); });
+
+    expect(targetId).toBe(30);
+    expect(result.current.currentId).toBe(30);
+    expect(result.current.queue?.videoIds).toEqual([10, 20, 30, 40]);
+    expect(loadNext).toHaveBeenCalledOnce();
+  });
+
+  it("reports the global position while lazily loading pages", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => <VideoQueueProvider>{children}</VideoQueueProvider>;
+    const { result } = renderHook(() => useVideoQueue(), { wrapper });
+    const loadPrevious = vi.fn().mockResolvedValue({ items: [{ id: 10 }, { id: 20 }], hasMore: false });
+
+    act(() => result.current.setQueue([30, 40], 30, undefined, { startIndex: 2, totalCount: 4, loadPrevious }));
+    expect(result.current.currentPosition).toBe(3);
+    expect(result.current.queueLength).toBe(4);
+    await act(async () => { await result.current.goPrevious(); });
+
+    expect(result.current.currentId).toBe(20);
+    expect(result.current.currentPosition).toBe(2);
+  });
+
+  it("ignores a boundary response after the queue is replaced", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => <VideoQueueProvider>{children}</VideoQueueProvider>;
+    const { result } = renderHook(() => useVideoQueue(), { wrapper });
+    let resolveLoad!: (value: { items: { id: number }[]; hasMore: boolean }) => void;
+    const loadNext = () => new Promise<{ items: { id: number }[]; hasMore: boolean }>((resolve) => { resolveLoad = resolve; });
+
+    act(() => result.current.setQueue([10, 20], 20, undefined, { startIndex: 0, totalCount: 4, loadNext }));
+    let pending!: Promise<number | null>;
+    act(() => { pending = result.current.goNext(); });
+    act(() => result.current.setQueue([90, 100], 90));
+    resolveLoad({ items: [{ id: 30 }, { id: 40 }], hasMore: false });
+    await act(async () => { await pending; });
+
+    expect(await pending).toBeNull();
+    expect(result.current.queue?.videoIds).toEqual([90, 100]);
+    expect(result.current.currentId).toBe(90);
+  });
+
+  it("ignores a boundary response after local navigation changes", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => <VideoQueueProvider>{children}</VideoQueueProvider>;
+    const { result } = renderHook(() => useVideoQueue(), { wrapper });
+    let resolveLoad!: (value: { items: { id: number }[]; hasMore: boolean }) => void;
+    const loadNext = () => new Promise<{ items: { id: number }[]; hasMore: boolean }>((resolve) => { resolveLoad = resolve; });
+
+    act(() => result.current.setQueue([10, 20], 20, undefined, { startIndex: 0, totalCount: 4, loadNext }));
+    let pending!: Promise<number | null>;
+    act(() => { pending = result.current.goNext(); });
+    act(() => { result.current.goToIndex(0); });
+    resolveLoad({ items: [{ id: 30 }, { id: 40 }], hasMore: false });
+    await act(async () => { await pending; });
+
+    expect(await pending).toBeNull();
+    expect(result.current.queue?.videoIds).toEqual([10, 20]);
+    expect(result.current.currentId).toBe(10);
+  });
+});

--- a/ui/src/utils/lightboxPagination.ts
+++ b/ui/src/utils/lightboxPagination.ts
@@ -1,0 +1,5 @@
+export interface LightboxPageBounds { first: number; last: number }
+
+export function extendLightboxPageBounds(bounds: LightboxPageBounds, page: number, direction: "previous" | "next") {
+  return direction === "previous" ? { ...bounds, first: page } : { ...bounds, last: page };
+}


### PR DESCRIPTION
## Summary

Continue video and image navigation across paginated list boundaries. Video playback queues and image lightboxes now lazily load adjacent pages while retaining the active filters, sort, seed, and page size. Image pagination works for both the top-level Images list and gallery image lists.

## Linked issue

Closes #62

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [x] AI was used for this PR.
  - **Model(s):** GPT-5 Codex
  - **Where / how:** Issue reproduction, Stash reference research, implementation, regression tests, live Playwright verification, and PR handoff drafting.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- Manual checks on images, galleries and videos.
  - Moving from the last item on a non-last page to the next item.
  - Moving from the first item on a non-first page to the previous item.
- New automated tests.

## Checklist

- [x] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [x] Builds and existing tests pass.
- [x] I added or updated tests where it makes sense.
- [x] I updated docs where needed. (No user-facing documentation change needed.)
- [x] This PR is focused and does not bundle unrelated changes.