### PR TITLE
Add keyboard navigation to entity autocomplete fields

### DIFF
--- a/ui/src/components/AutocompleteDropdown.tsx
+++ b/ui/src/components/AutocompleteDropdown.tsx
@@ -1,8 +1,9 @@
-import { useLayoutEffect, useState, type ReactNode, type RefObject } from "react";
+import { useLayoutEffect, useState, type HTMLAttributes, type ReactNode, type RefObject } from "react";
 import { createPortal } from "react-dom";
 
-interface Props {
+interface Props extends Omit<HTMLAttributes<HTMLDivElement>, "children" | "className"> {
   anchorRef: RefObject<HTMLElement | null>;
+  containerRef?: RefObject<HTMLDivElement | null>;
   children: ReactNode;
   className?: string;
   maxHeight?: number;
@@ -16,7 +17,7 @@ interface Position {
   placement: "above" | "below";
 }
 
-export function AutocompleteDropdown({ anchorRef, children, className, maxHeight = 160 }: Props) {
+export function AutocompleteDropdown({ anchorRef, containerRef, children, className, maxHeight = 160, ...containerProps }: Props) {
   const [position, setPosition] = useState<Position | null>(null);
 
   useLayoutEffect(() => {
@@ -64,6 +65,8 @@ export function AutocompleteDropdown({ anchorRef, children, className, maxHeight
 
   return createPortal(
     <div
+      ref={containerRef}
+      {...containerProps}
       className={`absolute z-[200] overflow-x-hidden overflow-y-auto shadow-lg ${className ?? ""}`}
       style={{
         left: position.left,

--- a/ui/src/components/EntityMultiSelector.tsx
+++ b/ui/src/components/EntityMultiSelector.tsx
@@ -1,10 +1,4 @@
-import { useMemo, useRef, useState } from "react";
-import { useQueries, useQuery } from "@tanstack/react-query";
-import { Plus, X } from "lucide-react";
-import { faces as facesApi, performers as performersApi, tags as tagsApi } from "../api/client";
-import type { Face, Performer, Tag } from "../api/types";
-import { rankSearchOptions } from "../utils/searchRanking";
-import { AutocompleteDropdown } from "./AutocompleteDropdown";
+import { EntityReferenceMultiSelector, type EntityReferenceType } from "./EntityReferenceSelector";
 
 type EntitySelectorType = "tags" | "performers" | "faces";
 
@@ -16,11 +10,11 @@ interface EntityMultiSelectorProps {
   emptyMessage?: string;
 }
 
-interface SearchOption {
-  id: number;
-  label: string;
-  secondaryLabel?: string;
-}
+const REFERENCE_TYPE: Record<EntitySelectorType, EntityReferenceType> = {
+  tags: "tag",
+  performers: "performer",
+  faces: "face",
+};
 
 export function EntityMultiSelector({
   entityType,
@@ -29,172 +23,14 @@ export function EntityMultiSelector({
   placeholder,
   emptyMessage,
 }: EntityMultiSelectorProps) {
-  const [searchText, setSearchText] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-  const trimmedSearch = searchText.trim();
-
-  const { data: searchResults, isLoading } = useQuery({
-    queryKey: ["entity-multi-selector", entityType, trimmedSearch],
-    queryFn: () => searchEntities(entityType, trimmedSearch),
-    enabled: trimmedSearch.length >= 1,
-    staleTime: 60_000,
-    placeholderData: (previousData) => previousData,
-  });
-
-  const searchOptions = useMemo(
-    () => rankSearchOptions(searchResults ?? [], trimmedSearch).slice(0, 25),
-    [searchResults, trimmedSearch],
-  );
-  const missingSelectedIds = useMemo(
-    () => values.filter((value) => !searchOptions.some((option) => option.id === value)),
-    [searchOptions, values],
-  );
-
-  const selectedQueries = useQueries({
-    queries: missingSelectedIds.map((id) => ({
-      queryKey: ["entity-multi-selector", entityType, "selected", id],
-      queryFn: () => getEntity(entityType, id),
-      staleTime: 60_000,
-    })),
-  });
-
-  const selectedOptions = useMemo(() => {
-    const optionMap = new Map<number, SearchOption>();
-    for (const option of searchOptions) {
-      optionMap.set(option.id, option);
-    }
-
-    for (const query of selectedQueries) {
-      if (!query.data) {
-        continue;
-      }
-
-      optionMap.set(query.data.id, query.data);
-    }
-
-    return values
-      .map((value) => optionMap.get(value))
-      .filter((option): option is SearchOption => option != null);
-  }, [searchOptions, selectedQueries, values]);
-
-  const visibleResults = useMemo(
-    () => searchOptions.filter((option) => !values.includes(option.id)),
-    [searchOptions, values],
-  );
-
   return (
-    <div className="relative flex flex-col gap-2">
-      {selectedOptions.length > 0 ? (
-        <div className="flex flex-wrap gap-1">
-          {selectedOptions.map((option) => (
-            <span key={option.id} className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-0.5 text-[10px] text-foreground">
-              <span>{option.label}</span>
-              {option.secondaryLabel ? <span className="text-muted">{option.secondaryLabel}</span> : null}
-              <button
-                type="button"
-                onClick={() => onChange(values.filter((value) => value !== option.id))}
-                className="hover:text-red-400"
-                aria-label={`Remove ${option.label}`}
-              >
-                <X className="h-2.5 w-2.5" />
-              </button>
-            </span>
-          ))}
-        </div>
-      ) : null}
-
-      <input
-        ref={inputRef}
-        type="text"
-        value={searchText}
-        onChange={(event) => setSearchText(event.target.value)}
-        placeholder={placeholder ?? `Search ${entityType}...`}
-        className="w-full rounded border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted focus:border-accent focus:outline-none"
-      />
-
-      {trimmedSearch ? (
-        <AutocompleteDropdown anchorRef={inputRef} className="rounded border border-border bg-surface">
-          {isLoading ? <div className="px-3 py-2 text-sm text-muted">Loading...</div> : null}
-          {!isLoading && visibleResults.length === 0 ? (
-            <div className="px-3 py-2 text-sm text-muted">{emptyMessage ?? `No ${entityType} found`}</div>
-          ) : null}
-          {visibleResults.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              onClick={() => {
-                onChange([...values, option.id]);
-                setSearchText("");
-              }}
-              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-foreground hover:bg-card"
-            >
-              <span className="inline-flex items-center gap-2">
-                <Plus className="h-3 w-3" />
-                <span>{option.label}</span>
-              </span>
-              {option.secondaryLabel ? <span className="text-xs text-muted">{option.secondaryLabel}</span> : null}
-            </button>
-          ))}
-        </AutocompleteDropdown>
-      ) : null}
-    </div>
+    <EntityReferenceMultiSelector
+      entityType={REFERENCE_TYPE[entityType]}
+      values={values}
+      onChange={onChange}
+      placeholder={placeholder}
+      emptyMessage={emptyMessage}
+      creatable={false}
+    />
   );
-}
-
-async function searchEntities(entityType: EntitySelectorType, searchText: string) {
-  switch (entityType) {
-    case "tags": {
-      const response = await tagsApi.find({ q: searchText || undefined, perPage: 100, sort: "name", direction: "asc" });
-      return response.items.map(toTagOption);
-    }
-    case "performers": {
-      const response = await performersApi.find({ q: searchText || undefined, perPage: 100, sort: "name", direction: "asc" });
-      return response.items.map(toPerformerOption);
-    }
-    case "faces": {
-      const response = await facesApi.list({ q: searchText || undefined, merged: false, page: 1, perPage: 100 });
-      return response.items.map(toFaceOption);
-    }
-  }
-}
-
-async function getEntity(entityType: EntitySelectorType, id: number) {
-  switch (entityType) {
-    case "tags":
-      return toTagOption(await tagsApi.get(id));
-    case "performers":
-      return toPerformerOption(await performersApi.get(id));
-    case "faces":
-      return toFaceOption(await facesApi.get(id));
-  }
-}
-
-function toTagOption(tag: Tag): SearchOption {
-  return {
-    id: tag.id,
-    label: tag.name,
-  };
-}
-
-function toPerformerOption(performer: Performer): SearchOption {
-  return {
-    id: performer.id,
-    label: performer.name,
-    secondaryLabel: performer.disambiguation ? `(${performer.disambiguation})` : undefined,
-  };
-}
-
-function toFaceOption(face: Face): SearchOption {
-  const label = face.label?.trim() || face.performerName?.trim() || "Unidentified face";
-  const secondaryLabel = face.performerName && face.performerName !== label
-    ? `Linked to ${face.performerName}`
-    : face.primarySourceKey
-      ? face.primarySourceKey
-      : undefined;
-
-  return {
-    id: face.id,
-    label,
-    secondaryLabel,
-  };
 }

--- a/ui/src/components/EntityReferenceSelector.tsx
+++ b/ui/src/components/EntityReferenceSelector.tsx
@@ -25,10 +25,12 @@ function buildReferenceAutocompleteItems(
   options: EntityReferenceOption[],
   createQuery: string | false | undefined,
   createPending: boolean,
+  optionsDisabled = false,
 ): AutocompleteItem<ReferenceAutocompleteValue>[] {
   const items: AutocompleteItem<ReferenceAutocompleteValue>[] = options.map((option) => ({
     key: `entity:${option.id}`,
     value: { kind: "entity", option },
+    disabled: optionsDisabled,
   }));
   if (createQuery) {
     items.push({
@@ -134,7 +136,7 @@ export function EntityReferenceSelector({
     return rankSearchOptions(cachedOptions.filter((option) => option.label.toLowerCase().includes(needle)), trimmedSearch).slice(0, 25);
   }, [cachedOptions, trimmedSearch]);
 
-  const { data: searchResults, isLoading, isFetching } = useQuery({
+  const { data: searchResults, isLoading, isFetching, isPlaceholderData } = useQuery({
     queryKey: ["entity-reference-selector", entityType, trimmedSearch],
     queryFn: () => searchEntityReferences(entityType, trimmedSearch),
     enabled: !disabled && trimmedSearch.length >= 1 && cachedSearchOptions == null,
@@ -189,14 +191,15 @@ export function EntityReferenceSelector({
 
   const showCreateOption = trimmedSearch && !isFetching && creatable && creatableTypes[entityType] && !exactMatchExists;
   const autocompleteItems = useMemo(
-    () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending),
-    [createMutation.isPending, showCreateOption, trimmedSearch, visibleResults],
+    () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending, isPlaceholderData),
+    [createMutation.isPending, isPlaceholderData, showCreateOption, trimmedSearch, visibleResults],
   );
   const autocomplete = useAutocomplete({
     items: autocompleteItems,
     inputValue: searchText,
     onInputValueChange: setSearchText,
     disabled,
+    busy: isPlaceholderData,
     onSelect: (item) => {
       if (item.kind === "create") {
         createMutation.mutate(item.query);
@@ -366,7 +369,7 @@ export function EntityReferenceMultiSelector({
     return rankSearchOptions(cachedOptions.filter((option) => option.label.toLowerCase().includes(needle)), trimmedSearch).slice(0, 25);
   }, [cachedOptions, trimmedSearch]);
 
-  const { data: searchResults, isLoading, isFetching } = useQuery({
+  const { data: searchResults, isLoading, isFetching, isPlaceholderData } = useQuery({
     queryKey: ["entity-reference-selector", entityType, trimmedSearch],
     queryFn: () => searchEntityReferences(entityType, trimmedSearch),
     enabled: !disabled && trimmedSearch.length >= 1 && cachedSearchOptions == null,
@@ -421,14 +424,15 @@ export function EntityReferenceMultiSelector({
 
   const showCreateOption = trimmedSearch && !isFetching && creatable && creatableTypes[entityType] && !exactMatchExists;
   const autocompleteItems = useMemo(
-    () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending),
-    [createMutation.isPending, showCreateOption, trimmedSearch, visibleResults],
+    () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending, isPlaceholderData),
+    [createMutation.isPending, isPlaceholderData, showCreateOption, trimmedSearch, visibleResults],
   );
   const autocomplete = useAutocomplete({
     items: autocompleteItems,
     inputValue: searchText,
     onInputValueChange: setSearchText,
     disabled,
+    busy: isPlaceholderData,
     onSelect: (item) => {
       if (item.kind === "create") {
         createMutation.mutate(item.query);

--- a/ui/src/components/EntityReferenceSelector.tsx
+++ b/ui/src/components/EntityReferenceSelector.tsx
@@ -101,6 +101,8 @@ export function EntityReferenceSelector({
   disabled = false,
   inputClassName,
   excludeIds,
+  creatable = true,
+  resultsMaxHeight,
   selectedDisplay = "chip",
   selectedLabel,
 }: {
@@ -111,6 +113,8 @@ export function EntityReferenceSelector({
   disabled?: boolean;
   inputClassName?: string;
   excludeIds?: Iterable<number>;
+  creatable?: boolean;
+  resultsMaxHeight?: number;
   selectedDisplay?: "chip" | "input";
   selectedLabel?: string;
 }) {
@@ -183,7 +187,7 @@ export function EntityReferenceSelector({
     },
   });
 
-  const showCreateOption = trimmedSearch && !isFetching && creatableTypes[entityType] && !exactMatchExists;
+  const showCreateOption = trimmedSearch && !isFetching && creatable && creatableTypes[entityType] && !exactMatchExists;
   const autocompleteItems = useMemo(
     () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending),
     [createMutation.isPending, showCreateOption, trimmedSearch, visibleResults],
@@ -259,6 +263,7 @@ export function EntityReferenceSelector({
         <AutocompleteDropdown
           anchorRef={autocomplete.inputRef}
           containerRef={autocomplete.listboxRef}
+          maxHeight={resultsMaxHeight}
           className="rounded border border-border bg-surface"
           {...autocomplete.listboxProps}
         >
@@ -316,6 +321,7 @@ export function EntityReferenceMultiSelector({
   containerClassName,
   excludeIds,
   lockedIds,
+  creatable = true,
   selectedProvenanceById,
   reportableIds,
   onReportIncorrect,
@@ -337,6 +343,7 @@ export function EntityReferenceMultiSelector({
   seedOptions?: EntityReferenceOption[];
   excludeIds?: Iterable<number>;
   lockedIds?: Iterable<number>;
+  creatable?: boolean;
   selectedProvenanceById?: Record<number, TagProvenance[] | undefined>;
   // Locked chips whose id is in reportableIds get the same "⋯" correction menu as the Details tab.
   reportableIds?: Iterable<number>;
@@ -412,7 +419,7 @@ export function EntityReferenceMultiSelector({
     },
   });
 
-  const showCreateOption = trimmedSearch && !isFetching && creatableTypes[entityType] && !exactMatchExists;
+  const showCreateOption = trimmedSearch && !isFetching && creatable && creatableTypes[entityType] && !exactMatchExists;
   const autocompleteItems = useMemo(
     () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending),
     [createMutation.isPending, showCreateOption, trimmedSearch, visibleResults],
@@ -647,10 +654,13 @@ function toPerformerOption(performer: Performer): EntityReferenceOption {
 }
 
 function toFaceOption(face: Face): EntityReferenceOption {
+  const label = face.label?.trim() || face.performerName?.trim() || "Unidentified face";
   return {
     id: face.id,
-    label: face.label?.trim() || face.performerName?.trim() || `Face #${face.id}`,
-    secondaryLabel: face.performerName && face.label?.trim() ? face.performerName : undefined,
+    label,
+    secondaryLabel: face.performerName && face.performerName !== label
+      ? face.performerName
+      : face.primarySourceKey || undefined,
   };
 }
 

--- a/ui/src/components/EntityReferenceSelector.tsx
+++ b/ui/src/components/EntityReferenceSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, X } from "lucide-react";
 import { faces, galleries, groups, images, performers, videos, studios, tags } from "../api/client";
@@ -7,6 +7,7 @@ import { TagProvenanceHover } from "./TagProvenanceHover";
 import { TagActionMenu } from "./shared";
 import { rankSearchOptions } from "../utils/searchRanking";
 import { AutocompleteDropdown } from "./AutocompleteDropdown";
+import { useAutocomplete, type AutocompleteItem } from "../hooks/useAutocomplete";
 
 export type EntityReferenceType = Extract<CustomFieldType, "tag" | "performer" | "studio" | "video" | "gallery" | "image" | "group"> | "face";
 
@@ -14,6 +15,29 @@ export interface EntityReferenceOption {
   id: number;
   label: string;
   secondaryLabel?: string;
+}
+
+type ReferenceAutocompleteValue =
+  | { kind: "entity"; option: EntityReferenceOption }
+  | { kind: "create"; query: string };
+
+function buildReferenceAutocompleteItems(
+  options: EntityReferenceOption[],
+  createQuery: string | false | undefined,
+  createPending: boolean,
+): AutocompleteItem<ReferenceAutocompleteValue>[] {
+  const items: AutocompleteItem<ReferenceAutocompleteValue>[] = options.map((option) => ({
+    key: `entity:${option.id}`,
+    value: { kind: "entity", option },
+  }));
+  if (createQuery) {
+    items.push({
+      key: `create:${createQuery.toLowerCase()}`,
+      value: { kind: "create", query: createQuery },
+      disabled: createPending,
+    });
+  }
+  return items;
 }
 
 const REFERENCE_TYPES = new Set<string>(["tag", "performer", "studio", "video", "gallery", "image", "group", "face"]);
@@ -91,7 +115,6 @@ export function EntityReferenceSelector({
   selectedLabel?: string;
 }) {
   const [searchText, setSearchText] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
   const trimmedSearch = searchText.trim();
   const labels = getEntityReferenceLabel(entityType);
   const queryClient = useQueryClient();
@@ -161,6 +184,24 @@ export function EntityReferenceSelector({
   });
 
   const showCreateOption = trimmedSearch && !isFetching && creatableTypes[entityType] && !exactMatchExists;
+  const autocompleteItems = useMemo(
+    () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending),
+    [createMutation.isPending, showCreateOption, trimmedSearch, visibleResults],
+  );
+  const autocomplete = useAutocomplete({
+    items: autocompleteItems,
+    inputValue: searchText,
+    onInputValueChange: setSearchText,
+    disabled,
+    onSelect: (item) => {
+      if (item.kind === "create") {
+        createMutation.mutate(item.query);
+        return false;
+      }
+      onChange(item.option.id, item.option);
+      setSearchText("");
+    },
+  });
 
   return (
     <div className="relative flex min-w-0 flex-col gap-2">
@@ -184,11 +225,12 @@ export function EntityReferenceSelector({
 
       <div className="relative">
         <input
-          ref={inputRef}
+          ref={autocomplete.inputRef}
+          {...autocomplete.inputProps}
           type="text"
           value={showSelectedInInput ? selectedInputLabel : searchText}
-          onChange={(event) => setSearchText(event.target.value)}
           onFocus={(event) => {
+            autocomplete.inputProps.onFocus(event);
             if (showSelectedInInput) {
               event.currentTarget.select();
             }
@@ -213,21 +255,23 @@ export function EntityReferenceSelector({
         ) : null}
       </div>
 
-      {trimmedSearch ? (
-        <AutocompleteDropdown anchorRef={inputRef} className="rounded border border-border bg-surface">
+      {trimmedSearch && autocomplete.isOpen ? (
+        <AutocompleteDropdown
+          anchorRef={autocomplete.inputRef}
+          containerRef={autocomplete.listboxRef}
+          className="rounded border border-border bg-surface"
+          {...autocomplete.listboxProps}
+        >
           {isLoading ? <div className="px-3 py-2 text-sm text-muted">Loading...</div> : null}
           {!isLoading && visibleResults.length === 0 && !showCreateOption ? (
             <div className="px-3 py-2 text-sm text-muted">No {labels.plural} found</div>
           ) : null}
-          {visibleResults.map((option) => (
+          {visibleResults.map((option, index) => (
             <button
               key={option.id}
+              {...autocomplete.getOptionProps<HTMLButtonElement>(autocompleteItems[index])}
               type="button"
-              onClick={() => {
-                onChange(option.id, option);
-                setSearchText("");
-              }}
-              className="flex w-full min-w-0 items-center justify-between gap-2 px-3 py-2 text-left text-sm text-foreground hover:bg-card"
+              className={`flex w-full min-w-0 items-center justify-between gap-2 px-3 py-2 text-left text-sm text-foreground hover:bg-card ${autocomplete.activeKey === autocompleteItems[index].key ? "bg-card" : ""}`}
             >
               <span className="inline-flex min-w-0 items-center gap-2">
                 <Plus className="h-3 w-3" />
@@ -238,10 +282,10 @@ export function EntityReferenceSelector({
           ))}
           {showCreateOption ? (
             <button
+              {...autocomplete.getOptionProps<HTMLButtonElement>(autocompleteItems[autocompleteItems.length - 1])}
               type="button"
-              onClick={() => createMutation.mutate(trimmedSearch)}
               disabled={createMutation.isPending}
-              className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-accent hover:bg-card disabled:opacity-50"
+              className={`flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-accent hover:bg-card disabled:opacity-50 ${autocomplete.activeKey === autocompleteItems[autocompleteItems.length - 1].key ? "bg-card" : ""}`}
             >
               {createMutation.isPending ? (
                 <span className="text-muted">Creating...</span>
@@ -300,7 +344,6 @@ export function EntityReferenceMultiSelector({
   onAdjustThreshold?: (id: number) => void;
 }) {
   const [searchText, setSearchText] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
   const trimmedSearch = searchText.trim();
   const labels = getEntityReferenceLabel(entityType);
   const queryClient = useQueryClient();
@@ -370,6 +413,24 @@ export function EntityReferenceMultiSelector({
   });
 
   const showCreateOption = trimmedSearch && !isFetching && creatableTypes[entityType] && !exactMatchExists;
+  const autocompleteItems = useMemo(
+    () => buildReferenceAutocompleteItems(visibleResults, showCreateOption ? trimmedSearch : false, createMutation.isPending),
+    [createMutation.isPending, showCreateOption, trimmedSearch, visibleResults],
+  );
+  const autocomplete = useAutocomplete({
+    items: autocompleteItems,
+    inputValue: searchText,
+    onInputValueChange: setSearchText,
+    disabled,
+    onSelect: (item) => {
+      if (item.kind === "create") {
+        createMutation.mutate(item.query);
+        return false;
+      }
+      onChange([...values, item.option.id]);
+      setSearchText("");
+    },
+  });
 
   return (
     <div className={`relative ${containerClassName ?? "flex flex-col gap-2"}`}>
@@ -410,30 +471,33 @@ export function EntityReferenceMultiSelector({
       ) : null}
 
       <input
-        ref={inputRef}
+        ref={autocomplete.inputRef}
+        {...autocomplete.inputProps}
         type="text"
         value={searchText}
-        onChange={(event) => setSearchText(event.target.value)}
         placeholder={placeholder ?? `Search ${labels.plural}...`}
         disabled={disabled}
         className={inputClassName ?? "w-full rounded border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted disabled:opacity-50 focus:border-accent focus:outline-none"}
       />
 
-      {trimmedSearch ? (
-        <AutocompleteDropdown anchorRef={inputRef} maxHeight={resultsMaxHeight} className={resultsClassName ?? "rounded border border-border bg-surface"}>
+      {trimmedSearch && autocomplete.isOpen ? (
+        <AutocompleteDropdown
+          anchorRef={autocomplete.inputRef}
+          containerRef={autocomplete.listboxRef}
+          maxHeight={resultsMaxHeight}
+          className={resultsClassName ?? "rounded border border-border bg-surface"}
+          {...autocomplete.listboxProps}
+        >
           {isLoading ? <div className="px-3 py-2 text-sm text-muted">Loading...</div> : null}
           {!isLoading && visibleResults.length === 0 && !showCreateOption ? (
             <div className="px-3 py-2 text-sm text-muted">{emptyMessage ?? `No ${labels.plural} found`}</div>
           ) : null}
-          {visibleResults.map((option) => (
+          {visibleResults.map((option, index) => (
             <button
               key={option.id}
+              {...autocomplete.getOptionProps<HTMLButtonElement>(autocompleteItems[index])}
               type="button"
-              onClick={() => {
-                onChange([...values, option.id]);
-                setSearchText("");
-              }}
-              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-foreground hover:bg-card"
+              className={`flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm text-foreground hover:bg-card ${autocomplete.activeKey === autocompleteItems[index].key ? "bg-card" : ""}`}
             >
               <span className="inline-flex items-center gap-2">
                 <Plus className="h-3 w-3" />
@@ -444,10 +508,10 @@ export function EntityReferenceMultiSelector({
           ))}
           {showCreateOption ? (
             <button
+              {...autocomplete.getOptionProps<HTMLButtonElement>(autocompleteItems[autocompleteItems.length - 1])}
               type="button"
-              onClick={() => createMutation.mutate(trimmedSearch)}
               disabled={createMutation.isPending}
-              className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-accent hover:bg-card disabled:opacity-50"
+              className={`flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-accent hover:bg-card disabled:opacity-50 ${autocomplete.activeKey === autocompleteItems[autocompleteItems.length - 1].key ? "bg-card" : ""}`}
             >
               {createMutation.isPending ? (
                 <span className="text-muted">Creating...</span>

--- a/ui/src/components/StudioSelector.tsx
+++ b/ui/src/components/StudioSelector.tsx
@@ -1,9 +1,4 @@
-import { useMemo, useRef, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plus, X } from "lucide-react";
-import { studios as studiosApi } from "../api/client";
-import { rankByLabel } from "../utils/searchRanking";
-import { AutocompleteDropdown } from "./AutocompleteDropdown";
+import { EntityReferenceSelector } from "./EntityReferenceSelector";
 
 interface StudioSelectorProps {
   value?: number;
@@ -12,115 +7,13 @@ interface StudioSelectorProps {
 }
 
 export function StudioSelector({ value, onChange, placeholder = "Search studios..." }: StudioSelectorProps) {
-  const [searchText, setSearchText] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-  const trimmedSearch = searchText.trim();
-  const queryClient = useQueryClient();
-
-  const { data: searchResults, isLoading, isFetching } = useQuery({
-    queryKey: ["studio-selector", trimmedSearch],
-    queryFn: async () => {
-      const response = await studiosApi.find({
-        q: trimmedSearch || undefined,
-        perPage: 100,
-        sort: "name",
-        direction: "asc",
-      });
-
-      return response.items;
-    },
-    staleTime: 60000,
-    enabled: trimmedSearch.length >= 1,
-    placeholderData: (previousData) => previousData,
-  });
-
-  const selectedResult = searchResults?.find((studio) => studio.id === value);
-
-  const { data: selectedStudio } = useQuery({
-    queryKey: ["studio-selector", "selected", value],
-    queryFn: async () => studiosApi.get(value as number),
-    enabled: typeof value === "number" && !selectedResult,
-    staleTime: 60000,
-  });
-
-  const selectedLabel = selectedResult?.name ?? selectedStudio?.name;
-  const visibleResults = useMemo(
-    () => rankByLabel((searchResults ?? []).filter((studio) => studio.id !== value), trimmedSearch, (studio) => studio.name).slice(0, 25),
-    [searchResults, trimmedSearch, value],
-  );
-
-  const exactMatchExists = trimmedSearch && (searchResults ?? []).some((s) => s.name.toLowerCase() === trimmedSearch.toLowerCase());
-  const createMutation = useMutation({
-    mutationFn: (name: string) => studiosApi.create({ name }),
-    onSuccess: (result) => {
-      onChange(result.id);
-      setSearchText("");
-      queryClient.invalidateQueries({ queryKey: ["studios"] });
-    },
-  });
-  const showCreateOption = trimmedSearch && !isFetching && !exactMatchExists;
-
   return (
-    <div className="relative flex flex-col gap-2">
-      {selectedLabel && (
-        <div className="flex flex-wrap gap-1">
-          <span className="inline-flex items-center gap-1 rounded border border-border bg-card px-2 py-0.5 text-[10px] text-foreground">
-            {selectedLabel}
-            <button onClick={() => onChange(undefined)} className="hover:text-red-400" aria-label="Clear selected studio">
-              <X className="h-2.5 w-2.5" />
-            </button>
-          </span>
-        </div>
-      )}
-
-      <input
-        ref={inputRef}
-        type="text"
-        value={searchText}
-        onChange={(e) => setSearchText(e.target.value)}
-        placeholder={placeholder}
-        className="w-full rounded border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted focus:border-accent focus:outline-none"
-      />
-
-      {trimmedSearch && (
-        <AutocompleteDropdown anchorRef={inputRef} maxHeight={128} className="rounded border border-border bg-surface">
-          {isLoading ? (
-            <div className="px-3 py-2 text-sm text-muted">Loading...</div>
-          ) : visibleResults.length === 0 && !showCreateOption ? (
-            <div className="px-3 py-2 text-sm text-muted">No studios found</div>
-          ) : null}
-          {visibleResults.map((studio) => (
-            <button
-              key={studio.id}
-              onClick={() => {
-                onChange(studio.id);
-                setSearchText("");
-              }}
-              className="flex w-full items-center gap-1 px-3 py-2 text-left text-sm text-foreground hover:bg-card"
-            >
-              <Plus className="h-3 w-3" />
-              {studio.name}
-            </button>
-          ))}
-          {showCreateOption ? (
-            <button
-              type="button"
-              onClick={() => createMutation.mutate(trimmedSearch)}
-              disabled={createMutation.isPending}
-              className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-sm text-accent hover:bg-card disabled:opacity-50"
-            >
-              {createMutation.isPending ? (
-                <span className="text-muted">Creating...</span>
-              ) : (
-                <>
-                  <Plus className="h-3 w-3" />
-                  <span>Create &ldquo;{trimmedSearch}&rdquo;</span>
-                </>
-              )}
-            </button>
-          ) : null}
-        </AutocompleteDropdown>
-      )}
-    </div>
+    <EntityReferenceSelector
+      entityType="studio"
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      resultsMaxHeight={128}
+    />
   );
 }

--- a/ui/src/hooks/useAutocomplete.ts
+++ b/ui/src/hooks/useAutocomplete.ts
@@ -25,6 +25,7 @@ interface UseAutocompleteOptions<T> {
   onInputValueChange: (value: string) => void;
   onSelect: (value: T) => boolean | void;
   disabled?: boolean;
+  busy?: boolean;
 }
 
 interface AutocompleteInputProps {
@@ -44,6 +45,7 @@ export function useAutocomplete<T>({
   onInputValueChange,
   onSelect,
   disabled = false,
+  busy = false,
 }: UseAutocompleteOptions<T>) {
   const generatedId = useId();
   const listboxId = `autocomplete-${generatedId}`;
@@ -80,6 +82,12 @@ export function useAutocomplete<T>({
       close();
     }
   }, [close, onSelect]);
+
+  useEffect(() => {
+    if (disabled) {
+      close();
+    }
+  }, [close, disabled]);
 
   useEffect(() => {
     if (previousInputValue.current === inputValue) return;
@@ -192,6 +200,7 @@ export function useAutocomplete<T>({
   const listboxProps: HTMLAttributes<HTMLDivElement> = {
     id: listboxId,
     role: "listbox",
+    "aria-busy": busy || undefined,
   };
 
   const getOptionProps = <TElement extends HTMLElement>(item: AutocompleteItem<T>): HTMLAttributes<TElement> & { ref: RefCallback<TElement> } => ({

--- a/ui/src/hooks/useAutocomplete.ts
+++ b/ui/src/hooks/useAutocomplete.ts
@@ -1,0 +1,227 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FocusEvent,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type RefCallback,
+  type RefObject,
+} from "react";
+
+export interface AutocompleteItem<T> {
+  key: string;
+  value: T;
+  disabled?: boolean;
+}
+
+interface UseAutocompleteOptions<T> {
+  items: AutocompleteItem<T>[];
+  inputValue: string;
+  onInputValueChange: (value: string) => void;
+  onSelect: (value: T) => boolean | void;
+  disabled?: boolean;
+}
+
+interface AutocompleteInputProps {
+  role: "combobox";
+  "aria-autocomplete": "list";
+  "aria-expanded": boolean;
+  "aria-controls": string;
+  "aria-activedescendant": string | undefined;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onFocus: (event: FocusEvent<HTMLInputElement>) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+export function useAutocomplete<T>({
+  items,
+  inputValue,
+  onInputValueChange,
+  onSelect,
+  disabled = false,
+}: UseAutocompleteOptions<T>) {
+  const generatedId = useId();
+  const listboxId = `autocomplete-${generatedId}`;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const optionElements = useRef(new Map<string, HTMLElement>());
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const previousInputValue = useRef(inputValue);
+
+  const selectableItems = useMemo(
+    () => items.filter((item) => !item.disabled),
+    [items],
+  );
+  const selectableKeys = useMemo(
+    () => selectableItems.map((item) => item.key),
+    [selectableItems],
+  );
+
+  const getOptionId = useCallback(
+    (key: string) => `${listboxId}-option-${encodeURIComponent(key).replaceAll("%", "_")}`,
+    [listboxId],
+  );
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setActiveKey(null);
+  }, []);
+
+  const selectItem = useCallback((item: AutocompleteItem<T>) => {
+    if (item.disabled) return;
+    const shouldClose = onSelect(item.value);
+    if (shouldClose !== false) {
+      close();
+    }
+  }, [close, onSelect]);
+
+  useEffect(() => {
+    if (previousInputValue.current === inputValue) return;
+    previousInputValue.current = inputValue;
+    setActiveKey(null);
+    setIsOpen(!disabled && inputValue.trim().length > 0);
+  }, [disabled, inputValue]);
+
+  useEffect(() => {
+    if (activeKey != null && !selectableKeys.includes(activeKey)) {
+      setActiveKey(null);
+    }
+  }, [activeKey, selectableKeys]);
+
+  useEffect(() => {
+    if (activeKey == null) return;
+    optionElements.current.get(activeKey)?.scrollIntoView?.({ block: "nearest" });
+  }, [activeKey]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (target && (inputRef.current?.contains(target) || listboxRef.current?.contains(target))) {
+        return;
+      }
+      close();
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [close, isOpen]);
+
+  const moveActive = useCallback((direction: 1 | -1) => {
+    if (selectableKeys.length === 0) return;
+    setIsOpen(true);
+    setActiveKey((current) => {
+      if (current == null) {
+        return direction === 1 ? selectableKeys[0] : selectableKeys[selectableKeys.length - 1];
+      }
+      const currentIndex = selectableKeys.indexOf(current);
+      if (currentIndex < 0) {
+        return direction === 1 ? selectableKeys[0] : selectableKeys[selectableKeys.length - 1];
+      }
+      const nextIndex = Math.max(0, Math.min(selectableKeys.length - 1, currentIndex + direction));
+      return selectableKeys[nextIndex];
+    });
+  }, [selectableKeys]);
+
+  const inputProps: AutocompleteInputProps = {
+    role: "combobox",
+    "aria-autocomplete": "list",
+    "aria-expanded": isOpen,
+    "aria-controls": listboxId,
+    "aria-activedescendant": activeKey == null ? undefined : getOptionId(activeKey),
+    onChange: (event) => {
+      const nextValue = event.target.value;
+      setActiveKey(null);
+      setIsOpen(!disabled && nextValue.trim().length > 0);
+      onInputValueChange(nextValue);
+    },
+    onFocus: () => {
+      if (!disabled && inputValue.trim().length > 0) {
+        setIsOpen(true);
+      }
+    },
+    onKeyDown: (event) => {
+      if (disabled) return;
+      switch (event.key) {
+        case "ArrowDown":
+          if (selectableKeys.length === 0) return;
+          event.preventDefault();
+          moveActive(1);
+          break;
+        case "ArrowUp":
+          if (selectableKeys.length === 0) return;
+          event.preventDefault();
+          moveActive(-1);
+          break;
+        case "Home":
+          if (!isOpen || selectableKeys.length === 0) return;
+          event.preventDefault();
+          setActiveKey(selectableKeys[0]);
+          break;
+        case "End":
+          if (!isOpen || selectableKeys.length === 0) return;
+          event.preventDefault();
+          setActiveKey(selectableKeys[selectableKeys.length - 1]);
+          break;
+        case "Enter": {
+          if (!isOpen || activeKey == null) return;
+          const item = items.find((candidate) => candidate.key === activeKey);
+          if (!item || item.disabled) return;
+          event.preventDefault();
+          selectItem(item);
+          break;
+        }
+        case "Escape":
+          if (!isOpen) return;
+          event.preventDefault();
+          event.stopPropagation();
+          close();
+          break;
+        case "Tab":
+          close();
+          break;
+      }
+    },
+  };
+
+  const listboxProps: HTMLAttributes<HTMLDivElement> = {
+    id: listboxId,
+    role: "listbox",
+  };
+
+  const getOptionProps = <TElement extends HTMLElement>(item: AutocompleteItem<T>): HTMLAttributes<TElement> & { ref: RefCallback<TElement> } => ({
+    id: getOptionId(item.key),
+    role: "option",
+    "aria-selected": activeKey === item.key,
+    "aria-disabled": item.disabled || undefined,
+    tabIndex: -1,
+    ref: (element: TElement | null) => {
+      if (element) {
+        optionElements.current.set(item.key, element);
+      } else {
+        optionElements.current.delete(item.key);
+      }
+    },
+    onMouseMove: () => {
+      if (!item.disabled) setActiveKey(item.key);
+    },
+    onMouseDown: (event) => event.preventDefault(),
+    onClick: () => selectItem(item),
+  });
+
+  return {
+    activeKey,
+    close,
+    getOptionProps,
+    inputProps,
+    inputRef,
+    isOpen,
+    listboxProps,
+    listboxRef: listboxRef as RefObject<HTMLDivElement | null>,
+  };
+}

--- a/ui/src/hooks/useAutocomplete.ts
+++ b/ui/src/hooks/useAutocomplete.ts
@@ -32,7 +32,7 @@ interface AutocompleteInputProps {
   role: "combobox";
   "aria-autocomplete": "list";
   "aria-expanded": boolean;
-  "aria-controls": string;
+  "aria-controls": string | undefined;
   "aria-activedescendant": string | undefined;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onFocus: (event: FocusEvent<HTMLInputElement>) => void;
@@ -140,7 +140,7 @@ export function useAutocomplete<T>({
     role: "combobox",
     "aria-autocomplete": "list",
     "aria-expanded": isOpen,
-    "aria-controls": listboxId,
+    "aria-controls": isOpen ? listboxId : undefined,
     "aria-activedescendant": activeKey == null ? undefined : getOptionId(activeKey),
     onChange: (event) => {
       const nextValue = event.target.value;
@@ -165,16 +165,6 @@ export function useAutocomplete<T>({
           if (selectableKeys.length === 0) return;
           event.preventDefault();
           moveActive(-1);
-          break;
-        case "Home":
-          if (!isOpen || selectableKeys.length === 0) return;
-          event.preventDefault();
-          setActiveKey(selectableKeys[0]);
-          break;
-        case "End":
-          if (!isOpen || selectableKeys.length === 0) return;
-          event.preventDefault();
-          setActiveKey(selectableKeys[selectableKeys.length - 1]);
           break;
         case "Enter": {
           if (!isOpen || activeKey == null) return;

--- a/ui/src/pages/PerformerEditModal.tsx
+++ b/ui/src/pages/PerformerEditModal.tsx
@@ -8,7 +8,8 @@ import { InteractiveRatingField } from "../components/Rating";
 import { CustomFieldsEditor, buildTagProvenanceById } from "../components/shared";
 import { StringListEditor } from "../components/StringListEditor";
 import { RemoteIdsEditor, normalizeRemoteIds, type RemoteIdValue } from "../components/RemoteIdsEditor";
-import { GroupedTagOptionList, SelectedTagChips, type SelectableTag } from "../components/TagSelector";
+import { SelectedTagChips, type SelectableTag } from "../components/TagSelector";
+import { useAutocomplete, type AutocompleteItem } from "../hooks/useAutocomplete";
 
 interface Props {
   performer: Performer;
@@ -31,6 +32,9 @@ export const CIRCUMCISED_OPTIONS = [
 ];
 
 type SelectedTagOption = SelectableTag;
+type TagAutocompleteValue =
+  | { kind: "tag"; tag: SelectedTagOption }
+  | { kind: "create"; query: string };
 
 function buildSelectedTagLookup(tags: Performer["tags"]): Record<number, SelectedTagOption> {
   return Object.fromEntries(tags.map((tag) => [tag.id, tag])) as Record<number, SelectedTagOption>;
@@ -151,9 +155,14 @@ export function PerformerEditModal({ performer, open, onClose }: Props) {
 
   const filteredTags = tagResults?.items.filter((tag) => !selectedTagIds.includes(tag.id)) ?? [];
   const tagExactMatchExists = useMemo(
-    () => trimmedTagSearch && filteredTags.some((tag) => tag.name.toLowerCase() === trimmedTagSearch.toLowerCase()),
-    [filteredTags, trimmedTagSearch],
+    () => trimmedTagSearch && tagResults?.items.some((tag) => tag.name.toLowerCase() === trimmedTagSearch.toLowerCase()),
+    [tagResults?.items, trimmedTagSearch],
   );
+  const addTag = (tag: SelectedTagOption) => {
+    setSelectedTagIds((current) => current.includes(tag.id) ? current : [...current, tag.id]);
+    setSelectedTagsById((current) => ({ ...current, [tag.id]: tag }));
+    setTagSearch("");
+  };
   const tagCreateMutation = useMutation({
     mutationFn: async (name: string) => tagsApi.create({ name }),
     onSuccess: (result) => {
@@ -162,16 +171,36 @@ export function PerformerEditModal({ performer, open, onClose }: Props) {
     },
   });
   const showTagCreateOption = trimmedTagSearch && !tagResultsLoading && !tagExactMatchExists;
+  const tagAutocompleteItems = useMemo<AutocompleteItem<TagAutocompleteValue>[]>(() => {
+    const items: AutocompleteItem<TagAutocompleteValue>[] = filteredTags.map((tag) => ({
+      key: `tag:${tag.id}`,
+      value: { kind: "tag", tag },
+    }));
+    if (showTagCreateOption) {
+      items.push({
+        key: `create:${trimmedTagSearch.toLowerCase()}`,
+        value: { kind: "create", query: trimmedTagSearch },
+        disabled: tagCreateMutation.isPending,
+      });
+    }
+    return items;
+  }, [filteredTags, showTagCreateOption, tagCreateMutation.isPending, trimmedTagSearch]);
+  const tagAutocomplete = useAutocomplete({
+    items: tagAutocompleteItems,
+    inputValue: tagSearch,
+    onInputValueChange: setTagSearch,
+    onSelect: (item) => {
+      if (item.kind === "create") {
+        tagCreateMutation.mutate(item.query);
+        return false;
+      }
+      addTag(item.tag);
+    },
+  });
   const selectedTags = selectedTagIds
     .map((tagId) => selectedTagsById[tagId])
     .filter((tag): tag is SelectedTagOption => Boolean(tag));
   const tagProvenanceById = buildTagProvenanceById(performer.tags, performer.fieldProvenance);
-
-  const addTag = (tag: SelectedTagOption) => {
-    setSelectedTagIds((current) => current.includes(tag.id) ? current : [...current, tag.id]);
-    setSelectedTagsById((current) => ({ ...current, [tag.id]: tag }));
-    setTagSearch("");
-  };
 
   return (
     <EditModal title="Edit Performer" open={open} onClose={onClose}>
@@ -311,28 +340,40 @@ export function PerformerEditModal({ performer, open, onClose }: Props) {
       <Field label="Tags" fieldProvenance={performer.fieldProvenance} fieldKey="tags">
         <SelectedTagChips tags={selectedTags} onRemove={(tag) => setSelectedTagIds((current) => current.filter((id) => id !== tag.id))} className="mb-2 flex flex-wrap gap-1.5" provenanceById={tagProvenanceById} />
         <input
+          ref={tagAutocomplete.inputRef}
+          {...tagAutocomplete.inputProps}
           type="text"
           value={tagSearch}
-          onChange={(e) => setTagSearch(e.target.value)}
           placeholder="Search tags..."
           className="w-full bg-card border border-border rounded px-3 py-1.5 text-sm text-foreground focus:outline-none focus:border-accent mb-1"
         />
-        {trimmedTagSearch && (
-          <div className="max-h-32 overflow-y-auto bg-card rounded border border-border">
+        {trimmedTagSearch && tagAutocomplete.isOpen && (
+          <div
+            ref={tagAutocomplete.listboxRef}
+            {...tagAutocomplete.listboxProps}
+            className="max-h-32 overflow-y-auto bg-card rounded border border-border"
+          >
             {tagResultsLoading ? (
               <div className="px-3 py-1.5 text-sm text-secondary">Loading...</div>
             ) : filteredTags.length === 0 && !showTagCreateOption ? (
               <div className="px-3 py-1.5 text-sm text-secondary">No tags found</div>
             ) : null}
-            {filteredTags.length > 0 ? (
-              <GroupedTagOptionList tags={filteredTags} maxItems={20} className="border-0 bg-transparent" onSelect={addTag} preserveOrder />
-            ) : null}
+            {filteredTags.map((tag, index) => (
+              <button
+                key={tag.id}
+                {...tagAutocomplete.getOptionProps<HTMLButtonElement>(tagAutocompleteItems[index])}
+                type="button"
+                className={`block w-full px-3 py-1.5 text-left text-sm text-foreground hover:bg-card ${tagAutocomplete.activeKey === tagAutocompleteItems[index].key ? "bg-card" : ""}`}
+              >
+                {tag.name}
+              </button>
+            ))}
             {showTagCreateOption ? (
               <button
+                {...tagAutocomplete.getOptionProps<HTMLButtonElement>(tagAutocompleteItems[tagAutocompleteItems.length - 1])}
                 type="button"
-                onClick={() => tagCreateMutation.mutate(trimmedTagSearch)}
                 disabled={tagCreateMutation.isPending}
-                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-accent hover:bg-card disabled:opacity-50"
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-accent hover:bg-card disabled:opacity-50 ${tagAutocomplete.activeKey === tagAutocompleteItems[tagAutocompleteItems.length - 1].key ? "bg-card" : ""}`}
               >
                 {tagCreateMutation.isPending ? (
                   <span className="text-secondary">Creating...</span>

--- a/ui/src/test/BulkEditDialog.test.tsx
+++ b/ui/src/test/BulkEditDialog.test.tsx
@@ -71,15 +71,15 @@ describe("BulkEditDialog", () => {
     await user.click(screen.getByRole("checkbox", { name: "Tags" }));
     await user.click(screen.getByRole("button", { name: "Overwrite" }));
   await user.type(screen.getByPlaceholderText("Search tags..."), "Tag");
-    await waitFor(() => expect(screen.getByRole("button", { name: /Tag One/i })).toBeInTheDocument());
-    await user.click(screen.getByRole("button", { name: /Tag One/i }));
+    await waitFor(() => expect(screen.getByRole("option", { name: /Tag One/i })).toBeInTheDocument());
+    await user.click(screen.getByRole("option", { name: /Tag One/i }));
 
     await user.click(screen.getByRole("checkbox", { name: "Groups" }));
     const overwriteButtons = screen.getAllByRole("button", { name: "Overwrite" });
     await user.click(overwriteButtons[1]);
   await user.type(screen.getByPlaceholderText("Search groups..."), "Series");
-    await waitFor(() => expect(screen.getByRole("button", { name: /Series One/i })).toBeInTheDocument());
-    await user.click(screen.getByRole("button", { name: /Series One/i }));
+    await waitFor(() => expect(screen.getByRole("option", { name: /Series One/i })).toBeInTheDocument());
+    await user.click(screen.getByRole("option", { name: /Series One/i }));
 
     await user.click(screen.getByRole("button", { name: "Apply" }));
 
@@ -111,8 +111,8 @@ describe("BulkEditDialog", () => {
     await user.click(screen.getByRole("checkbox", { name: "Studio" }));
     const searchInput = screen.getByPlaceholderText("Search studios...");
     await user.type(searchInput, "Alpha");
-    await waitFor(() => expect(screen.getByRole("button", { name: /Alpha Studio/i })).toBeInTheDocument());
-    await user.click(screen.getByRole("button", { name: /Alpha Studio/i }));
+    await waitFor(() => expect(screen.getByRole("option", { name: /Alpha Studio/i })).toBeInTheDocument());
+    await user.click(screen.getByRole("option", { name: /Alpha Studio/i }));
 
     await user.click(screen.getByRole("button", { name: "Apply" }));
 

--- a/ui/src/test/EntityReferenceSelector.test.tsx
+++ b/ui/src/test/EntityReferenceSelector.test.tsx
@@ -181,6 +181,7 @@ describe("EntityReferenceMultiSelector", () => {
 
   it("keeps the dropdown results mounted while the next search is loading", async () => {
     const user = userEvent.setup();
+    const onChange = vi.fn();
     let resolveNextSearch!: (value: { items: Array<{ id: number; name: string }> }) => void;
     const nextSearch = new Promise<{ items: Array<{ id: number; name: string }> }>((resolve) => {
       resolveNextSearch = resolve;
@@ -192,7 +193,7 @@ describe("EntityReferenceMultiSelector", () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={vi.fn()} />
+        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={onChange} />
       </QueryClientProvider>,
     );
 
@@ -215,7 +216,12 @@ describe("EntityReferenceMultiSelector", () => {
     await user.type(input, "a");
     await waitFor(() => expect(mocks.tagsFind).toHaveBeenCalledTimes(2));
     expect(screen.getByRole("option", { name: /Massage/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Massage/i })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("listbox")).toHaveAttribute("aria-busy", "true");
     expect(input).not.toHaveAttribute("aria-activedescendant");
+    await user.keyboard("{ArrowDown}{Enter}");
+    await user.click(screen.getByRole("option", { name: /Massage/i }));
+    expect(onChange).not.toHaveBeenCalled();
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
     expect(screen.queryByRole("option", { name: "Create “ma”" })).not.toBeInTheDocument();
 

--- a/ui/src/test/EntityReferenceSelector.test.tsx
+++ b/ui/src/test/EntityReferenceSelector.test.tsx
@@ -118,6 +118,22 @@ describe("EntityReferenceMultiSelector", () => {
     await waitFor(() => expect(onChange).toHaveBeenCalledWith([12]));
   });
 
+  it("can suppress creation for selector contexts that only accept existing entities", async () => {
+    const user = userEvent.setup();
+    mocks.tagsFind.mockResolvedValue({ items: [] });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={vi.fn()} creatable={false} />
+      </QueryClientProvider>,
+    );
+
+    await user.type(screen.getByPlaceholderText("Search tags..."), "Missing");
+    expect(await screen.findByText("No tags found")).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Create/i })).not.toBeInTheDocument();
+  });
+
   it("does not render a remove button for locked tag chips", async () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     queryClient.setQueryData(["entity-reference-selector", "tag", "selected", 1], { id: 1, label: "Manual" });

--- a/ui/src/test/EntityReferenceSelector.test.tsx
+++ b/ui/src/test/EntityReferenceSelector.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { EntityReferenceMultiSelector } from "../components/EntityReferenceSelector";
 
-const mocks = vi.hoisted(() => ({ tagsFind: vi.fn() }));
+const mocks = vi.hoisted(() => ({ tagsCreate: vi.fn(), tagsFind: vi.fn() }));
 
 vi.mock("../api/client", () => ({
   faces: {},
@@ -14,16 +14,110 @@ vi.mock("../api/client", () => ({
   images: {},
   performers: {},
   studios: {},
-  tags: { find: mocks.tagsFind },
+  tags: { create: mocks.tagsCreate, find: mocks.tagsFind },
   videos: {},
 }));
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.clearAllMocks();
   vi.unstubAllGlobals();
 });
 
 describe("EntityReferenceMultiSelector", () => {
+  it("exposes portal-rendered combobox options and selects the active option with clamped keyboard navigation", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mocks.tagsFind.mockResolvedValue({
+      items: [
+        { id: 1, name: "Massage" },
+        { id: 2, name: "Makeup" },
+      ],
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={onChange} />
+      </QueryClientProvider>,
+    );
+
+    const input = screen.getByPlaceholderText("Search tags...");
+    await user.type(input, "Makeup");
+    const firstOption = await screen.findByRole("option", { name: /Makeup/i });
+    const secondOption = screen.getByRole("option", { name: /Massage/i });
+    const listbox = screen.getByRole("listbox");
+
+    expect(input).toHaveAttribute("role", "combobox");
+    expect(input).toHaveAttribute("aria-autocomplete", "list");
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    expect(input).toHaveAttribute("aria-controls", listbox.id);
+    expect(listbox.parentElement).toBe(document.body);
+
+    const scrollIntoView = vi.fn();
+    firstOption.scrollIntoView = scrollIntoView;
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveAttribute("aria-activedescendant", firstOption.id);
+    expect(firstOption).toHaveAttribute("aria-selected", "true");
+    expect(document.activeElement).toBe(input);
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+
+    await user.keyboard("{ArrowDown}{ArrowDown}");
+    expect(input).toHaveAttribute("aria-activedescendant", secondOption.id);
+
+    await user.keyboard("{Enter}");
+    expect(onChange).toHaveBeenCalledWith([1]);
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("closes on Escape without clearing the query or selection", async () => {
+    const user = userEvent.setup();
+    mocks.tagsFind.mockResolvedValue({ items: [{ id: 1, name: "Massage" }] });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    const input = screen.getByPlaceholderText("Search tags...");
+    await user.type(input, "mass");
+    await screen.findByRole("option", { name: /Massage/i });
+    await user.keyboard("{ArrowDown}{Escape}");
+
+    expect(input).toHaveValue("mass");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("activates the create option from the keyboard", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mocks.tagsFind.mockResolvedValue({ items: [] });
+    mocks.tagsCreate.mockResolvedValue({ id: 12, name: "Novel tag" });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={onChange} />
+      </QueryClientProvider>,
+    );
+
+    const input = screen.getByPlaceholderText("Search tags...");
+    await user.type(input, "Novel tag");
+    const createOption = await screen.findByRole("option", { name: "Create “Novel tag”" });
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveAttribute("aria-activedescendant", createOption.id);
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => expect(mocks.tagsCreate).toHaveBeenCalledWith({ name: "Novel tag" }));
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([12]));
+  });
+
   it("does not render a remove button for locked tag chips", async () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     queryClient.setQueryData(["entity-reference-selector", "tag", "selected", 1], { id: 1, label: "Manual" });
@@ -94,19 +188,23 @@ describe("EntityReferenceMultiSelector", () => {
     vi.stubGlobal("scrollY", 480);
     vi.stubGlobal("visualViewport", { pageLeft: 0, pageTop: 500, height: 300, addEventListener: vi.fn(), removeEventListener: vi.fn() });
     await user.type(input, "m");
-    const firstResult = await screen.findByRole("button", { name: /Massage/i });
+    const firstResult = await screen.findByRole("option", { name: /Massage/i });
     const dropdown = firstResult.parentElement;
     expect(dropdown).toHaveClass("absolute", "z-[200]", "overflow-y-auto", "overflow-x-hidden");
     expect(dropdown?.parentElement).toBe(document.body);
     expect(dropdown).toHaveStyle({ left: "20px", top: "624px", width: "200px" });
 
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveAttribute("aria-activedescendant", firstResult.id);
     await user.type(input, "a");
     await waitFor(() => expect(mocks.tagsFind).toHaveBeenCalledTimes(2));
-    expect(screen.getByRole("button", { name: /Massage/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Massage/i })).toBeInTheDocument();
+    expect(input).not.toHaveAttribute("aria-activedescendant");
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Create “ma”" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Create “ma”" })).not.toBeInTheDocument();
 
     resolveNextSearch({ items: [{ id: 2, name: "Makeup" }] });
-    expect(await screen.findByRole("button", { name: /Makeup/i })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: /Makeup/i })).toBeInTheDocument();
+    expect(input).not.toHaveAttribute("aria-activedescendant");
   });
 });

--- a/ui/src/test/EntityReferenceSelector.test.tsx
+++ b/ui/src/test/EntityReferenceSelector.test.tsx
@@ -1,9 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { EntityReferenceMultiSelector } from "../components/EntityReferenceSelector";
+import { EntityReferenceMultiSelector, EntityReferenceSelector } from "../components/EntityReferenceSelector";
 
 const mocks = vi.hoisted(() => ({ tagsCreate: vi.fn(), tagsFind: vi.fn() }));
 
@@ -89,9 +89,38 @@ describe("EntityReferenceMultiSelector", () => {
 
     expect(input).toHaveValue("mass");
     expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(input).not.toHaveAttribute("aria-controls");
     expect(input).not.toHaveAttribute("aria-activedescendant");
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(document.activeElement).toBe(input);
+  });
+
+  it("closes on Tab and an outside pointer interaction while preserving native editable keys", async () => {
+    const user = userEvent.setup();
+    mocks.tagsFind.mockResolvedValue({ items: [{ id: 1, name: "Massage" }] });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntityReferenceMultiSelector entityType="tag" values={[]} onChange={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    const input = screen.getByPlaceholderText("Search tags...");
+    await user.type(input, "mass");
+    await screen.findByRole("option", { name: /Massage/i });
+
+    expect(fireEvent.keyDown(input, { key: "Home" })).toBe(true);
+    expect(fireEvent.keyDown(input, { key: "End" })).toBe(true);
+    await user.keyboard("{Tab}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(input).toHaveValue("mass");
+
+    await user.click(input);
+    expect(await screen.findByRole("listbox")).toBeInTheDocument();
+    await user.click(document.body);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(input).toHaveValue("mass");
   });
 
   it("activates the create option from the keyboard", async () => {
@@ -228,5 +257,30 @@ describe("EntityReferenceMultiSelector", () => {
     resolveNextSearch({ items: [{ id: 2, name: "Makeup" }] });
     expect(await screen.findByRole("option", { name: /Makeup/i })).toBeInTheDocument();
     expect(input).not.toHaveAttribute("aria-activedescendant");
+  });
+});
+
+describe("EntityReferenceSelector", () => {
+  it("selects an active option from the keyboard and returns its metadata", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mocks.tagsFind.mockResolvedValue({ items: [{ id: 7, name: "Massage" }] });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntityReferenceSelector entityType="tag" onChange={onChange} creatable={false} />
+      </QueryClientProvider>,
+    );
+
+    const input = screen.getByPlaceholderText("Search tags...");
+    await user.type(input, "mass");
+    const option = await screen.findByRole("option", { name: /Massage/i });
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith(7, expect.objectContaining({ id: 7, label: "Massage" }));
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(option).not.toBeInTheDocument();
   });
 });

--- a/ui/src/test/FilterDialog.test.tsx
+++ b/ui/src/test/FilterDialog.test.tsx
@@ -219,7 +219,7 @@ describe("FilterDialog", () => {
 
     fireEvent.click(screen.getByText("Tag Duration"));
     fireEvent.change(screen.getByPlaceholderText("Search tags"), { target: { value: "Action" } });
-    fireEvent.click(screen.getByRole("button", { name: "Action" }));
+    fireEvent.click(screen.getByRole("option", { name: "Action" }));
 
     expect(screen.queryByRole("button", { name: "Remove Tag Duration filter chip" })).not.toBeInTheDocument();
 
@@ -248,7 +248,7 @@ describe("FilterDialog", () => {
     expect(screen.queryByRole("option", { name: "Any" })).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByPlaceholderText("Search tags"), { target: { value: "Action" } });
-    fireEvent.click(screen.getByRole("button", { name: "Action" }));
+    fireEvent.click(screen.getByRole("option", { name: "Action" }));
     fireEvent.change(screen.getByLabelText("Tag duration time"), { target: { value: "1:30" } });
     fireEvent.blur(screen.getByLabelText("Tag duration time"));
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));
@@ -299,14 +299,14 @@ describe("FilterDialog", () => {
 
     fireEvent.click(screen.getByText("Tag Duration"));
     fireEvent.change(screen.getByPlaceholderText("Search tags"), { target: { value: "Action" } });
-    fireEvent.click(screen.getByRole("button", { name: "Action" }));
+    fireEvent.click(screen.getByRole("option", { name: "Action" }));
     fireEvent.change(screen.getByLabelText("Tag duration time"), { target: { value: "0:30" } });
     fireEvent.blur(screen.getByLabelText("Tag duration time"));
     fireEvent.click(screen.getByRole("button", { name: "Add tag duration" }));
 
     const searchInputs = screen.getAllByPlaceholderText("Search tags");
     fireEvent.change(searchInputs[1], { target: { value: "Mood" } });
-    fireEvent.click(screen.getByRole("button", { name: "Mood" }));
+    fireEvent.click(screen.getByRole("option", { name: "Mood" }));
     fireEvent.change(screen.getAllByLabelText("Tag duration unit")[1], { target: { value: "percent" } });
     fireEvent.change(screen.getByLabelText("Tag duration percent"), { target: { value: "10" } });
     fireEvent.click(screen.getByRole("button", { name: "Apply" }));

--- a/ui/src/test/PerformerEditModal.test.tsx
+++ b/ui/src/test/PerformerEditModal.test.tsx
@@ -7,6 +7,7 @@ import type { Performer } from "../api/types";
 
 const mocks = vi.hoisted(() => ({
   performersUpdate: vi.fn(),
+  tagsCreate: vi.fn(),
   tagsFind: vi.fn(),
   performerImageUrl: vi.fn(),
   uploadPerformerImage: vi.fn(),
@@ -15,7 +16,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../api/client", () => ({
   performers: { update: mocks.performersUpdate },
-  tags: { find: mocks.tagsFind },
+  tags: { create: mocks.tagsCreate, find: mocks.tagsFind },
   entityImages: {
     performerImageUrl: mocks.performerImageUrl,
     uploadPerformerImage: mocks.uploadPerformerImage,
@@ -144,11 +145,53 @@ describe("PerformerEditModal", () => {
       });
     });
 
-    await user.click(await screen.findByRole("button", { name: "Shaved Pussy" }));
+    await user.click(await screen.findByRole("option", { name: "Shaved Pussy" }));
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(mocks.performersUpdate).toHaveBeenCalledWith(1, expect.objectContaining({ tagIds: [7] })));
     expect(screen.getByText("Shaved Pussy")).toBeInTheDocument();
+  });
+
+  it("creates and selects a metadata-rich tag with the shared keyboard interaction", async () => {
+    const user = userEvent.setup();
+    const performer: Performer = {
+      id: 1,
+      name: "Sample Performer",
+      favorite: false,
+      urls: [],
+      aliases: [],
+      tags: [],
+      remoteIds: [],
+      videoCount: 0,
+      imageCount: 0,
+      galleryCount: 0,
+      groupCount: 0,
+      audioCount: 0,
+      textCount: 0,
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+    };
+    mocks.tagsFind.mockResolvedValue({ items: [] });
+    mocks.tagsCreate.mockResolvedValue({
+      id: 9,
+      name: "Novel tag",
+      color: "#123456",
+      tagGroupName: "Qualities",
+      tagGroupColor: "#654321",
+    });
+
+    renderModal(performer);
+
+    const input = screen.getByPlaceholderText("Search tags...");
+    await user.type(input, "Novel tag");
+    const createOption = await screen.findByRole("option", { name: "Create “Novel tag”" });
+    expect(input).toHaveAttribute("aria-controls", createOption.parentElement?.id);
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    await waitFor(() => expect(mocks.tagsCreate).toHaveBeenCalledWith({ name: "Novel tag" }));
+    expect(await screen.findByText("Qualities")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mocks.performersUpdate).toHaveBeenCalledWith(1, expect.objectContaining({ tagIds: [9] })));
   });
 
   it("saves aliases from separate list inputs", async () => {


### PR DESCRIPTION
## Summary

- Adds a reusable stable-key autocomplete interaction hook with clamped keyboard navigation, Escape/Tab/outside closing, active-option scrolling, and WAI-ARIA combobox/listbox wiring.
- Migrates the shared single- and multi-entity selectors and the performer tag picker to the reusable behavior while preserving portal positioning, tag metadata, tag creation, provenance, locked values, and mouse selection.
- Reduces `EntityMultiSelector` and `StudioSelector` to compatibility adapters over the shared entity selectors, removing their duplicated fetching and result rendering.
- Keeps React Query placeholder results visible during replacement but marks them busy and non-selectable until the current query resolves.
- Leaves the filter dialog's include/exclude result rows unchanged because they are an action list with multiple controls per entity, not a conventional listbox.

## Linked issue

Closed #65 

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / tech debt
- [ ] Docs
- [ ] Other

## AI usage

- [ ] No AI was used for this PR.
- [x] AI was used for this PR.
  - **Model(s):** GPT-5 Codex
  - **Where / how:** Consumer investigation, accessibility design, implementation, tests, browser verification, and review preparation.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- New automated tests.
- Extensive manual tests on all autocomplete inputs.

## Checklist

- [x] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [x] Builds and existing tests pass.
- [x] I added or updated tests where it makes sense.
- [x] I updated docs where needed.
- [x] This PR is focused and does not bundle unrelated changes.