### PR TITLE
Fix gaps in Stash migration

### DIFF
--- a/src/Cove.Api/Services/StashMigrationService.Galleries.cs
+++ b/src/Cove.Api/Services/StashMigrationService.Galleries.cs
@@ -6,7 +6,7 @@ namespace Cove.Api.Services;
 
 public partial class StashMigrationService
 {
-    private async Task<(int Count, Dictionary<int, int> GalleryFileIdMap)> ImportGalleriesAsync(
+    private async Task<(int Count, Dictionary<int, int> GalleryFileIdMap, Dictionary<int, int> GalleryIdMap)> ImportGalleriesAsync(
         SqliteConnection conn,
         Dictionary<int, int> folderIdMap,
         Dictionary<int, int> studioIdMap,
@@ -21,7 +21,7 @@ public partial class StashMigrationService
         if (!await TableExistsAsync(conn, "galleries", ct))
         {
             _logger.LogInformation("No galleries table found, skipping");
-            return (0, new Dictionary<int, int>());
+            return (0, new Dictionary<int, int>(), new Dictionary<int, int>());
         }
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
@@ -213,6 +213,56 @@ public partial class StashMigrationService
             RatingHostType.Gallery,
             ct);
         _logger.LogInformation("Imported {Count} galleries in {Elapsed}", count, stopwatch.Elapsed);
-        return (count, galleryFileIdMap);
+        return (count, galleryFileIdMap, galleryIdMap);
+    }
+
+    private async Task<int> ImportVideoGalleryRelationshipsAsync(
+        SqliteConnection conn,
+        IReadOnlyDictionary<int, int> sceneIdMap,
+        IReadOnlyDictionary<int, int> galleryIdMap,
+        CancellationToken ct)
+    {
+        if (!await TableExistsAsync(conn, "scenes_galleries", ct))
+        {
+            _logger.LogInformation("No scenes_galleries table found, skipping video-gallery relationships");
+            return 0;
+        }
+
+        const int RelationshipBatchSize = 5000;
+        var relationships = new List<VideoGallery>(RelationshipBatchSize);
+        var mappedRelationships = new HashSet<(int VideoId, int GalleryId)>();
+        var count = 0;
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT scene_id, gallery_id FROM scenes_galleries";
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            if (!sceneIdMap.TryGetValue(reader.GetInt32(0), out var videoId)
+                || !galleryIdMap.TryGetValue(reader.GetInt32(1), out var galleryId)
+                || !mappedRelationships.Add((videoId, galleryId)))
+            {
+                continue;
+            }
+
+            relationships.Add(new VideoGallery { VideoId = videoId, GalleryId = galleryId });
+            if (relationships.Count < RelationshipBatchSize)
+                continue;
+
+            _db.Set<VideoGallery>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+            relationships.Clear();
+            _db.ChangeTracker.Clear();
+        }
+
+        if (relationships.Count > 0)
+        {
+            _db.Set<VideoGallery>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+        }
+
+        _logger.LogInformation("Imported {Count} video-gallery relationships", count);
+        return count;
     }
 }

--- a/src/Cove.Api/Services/StashMigrationService.Galleries.cs
+++ b/src/Cove.Api/Services/StashMigrationService.Galleries.cs
@@ -43,16 +43,21 @@ public partial class StashMigrationService
         }
 
         var galleryImages = new Dictionary<int, List<int>>();
+        var galleryCoverImages = new Dictionary<int, int>();
         if (await TableExistsAsync(conn, "galleries_images", ct))
         {
+            var hasCoverColumn = await ColumnExistsAsync(conn, "galleries_images", "cover", ct);
             await using var cmd = conn.CreateCommand();
-            cmd.CommandText = "SELECT gallery_id, image_id FROM galleries_images";
+            cmd.CommandText = $"SELECT gallery_id, image_id, {(hasCoverColumn ? "cover" : "0")} AS cover FROM galleries_images";
             await using var r = await cmd.ExecuteReaderAsync(ct);
             while (await r.ReadAsync(ct))
             {
                 var gid = r.GetInt32(0);
                 if (!galleryImages.TryGetValue(gid, out var list)) galleryImages[gid] = list = [];
-                list.Add(r.GetInt32(1));
+                var imageId = r.GetInt32(1);
+                list.Add(imageId);
+                if (r.GetBoolean(2))
+                    galleryCoverImages[gid] = imageId;
             }
         }
 
@@ -136,6 +141,9 @@ public partial class StashMigrationService
                 Organized = row.Organized,
                 FolderId = row.FolderId.HasValue && folderIdMap.TryGetValue(row.FolderId.Value, out var fid) ? fid : null,
                 StudioId = row.StudioId.HasValue && studioIdMap.TryGetValue(row.StudioId.Value, out var sid) ? sid : null,
+                CoverImageId = galleryCoverImages.TryGetValue(stashId, out var coverImageId) && imageIdMap.TryGetValue(coverImageId, out var coveCoverImageId)
+                    ? coveCoverImageId
+                    : null,
                 CreatedAt = ParseDateTime(row.CreatedAt),
                 UpdatedAt = ParseDateTime(row.UpdatedAt),
                 Urls = galleryUrls.GetValueOrDefault(stashId, []).Select(u => new GalleryUrl { Url = u }).ToList(),

--- a/src/Cove.Api/Services/StashMigrationService.Groups.cs
+++ b/src/Cove.Api/Services/StashMigrationService.Groups.cs
@@ -154,6 +154,64 @@ public partial class StashMigrationService
         return count;
     }
 
+    private async Task<int> ImportGroupRelationsAsync(
+        SqliteConnection conn,
+        IReadOnlyDictionary<int, int> groupIdMap,
+        CancellationToken ct)
+    {
+        if (!await TableExistsAsync(conn, "groups_relations", ct))
+        {
+            _logger.LogInformation("No groups_relations table found, skipping group relations");
+            return 0;
+        }
+
+        const int RelationshipBatchSize = 5000;
+        var relationships = new List<GroupRelation>(RelationshipBatchSize);
+        var mappedRelationships = new HashSet<(int ContainingGroupId, int SubGroupId)>();
+        var count = 0;
+        await using var cmd = conn.CreateCommand();
+        // Distinct Stash groups can collapse to one Cove group. Process source IDs deterministically so
+        // the lowest ordered source pair supplies order/description when multiple pairs map to one link.
+        cmd.CommandText = "SELECT containing_id, sub_id, order_index, description FROM groups_relations ORDER BY containing_id, sub_id";
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            if (!groupIdMap.TryGetValue(reader.GetInt32(0), out var containingGroupId)
+                || !groupIdMap.TryGetValue(reader.GetInt32(1), out var subGroupId)
+                || containingGroupId == subGroupId
+                || !mappedRelationships.Add((containingGroupId, subGroupId)))
+            {
+                continue;
+            }
+
+            relationships.Add(new GroupRelation
+            {
+                ContainingGroupId = containingGroupId,
+                SubGroupId = subGroupId,
+                OrderIndex = reader.GetInt32(2),
+                Description = ReadStringNull(reader, 3),
+            });
+            if (relationships.Count < RelationshipBatchSize)
+                continue;
+
+            _db.Set<GroupRelation>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+            relationships.Clear();
+            _db.ChangeTracker.Clear();
+        }
+
+        if (relationships.Count > 0)
+        {
+            _db.Set<GroupRelation>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+        }
+
+        _logger.LogInformation("Imported {Count} group relations", count);
+        return count;
+    }
+
     private sealed record StashGroupImportUnit(
         IReadOnlyList<int> StashIds,
         string Name,

--- a/src/Cove.Api/Services/StashMigrationService.Groups.cs
+++ b/src/Cove.Api/Services/StashMigrationService.Groups.cs
@@ -104,6 +104,56 @@ public partial class StashMigrationService
         return idMap;
     }
 
+    private async Task<int> ImportGroupTagRelationshipsAsync(
+        SqliteConnection conn,
+        IReadOnlyDictionary<int, int> groupIdMap,
+        IReadOnlyDictionary<int, int> tagIdMap,
+        CancellationToken ct)
+    {
+        if (!await TableExistsAsync(conn, "groups_tags", ct))
+        {
+            _logger.LogInformation("No groups_tags table found, skipping group-tag relationships");
+            return 0;
+        }
+
+        const int RelationshipBatchSize = 5000;
+        var relationships = new List<GroupTag>(RelationshipBatchSize);
+        var mappedRelationships = new HashSet<(int GroupId, int TagId)>();
+        var count = 0;
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT group_id, tag_id FROM groups_tags";
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            if (!groupIdMap.TryGetValue(reader.GetInt32(0), out var groupId)
+                || !tagIdMap.TryGetValue(reader.GetInt32(1), out var tagId)
+                || !mappedRelationships.Add((groupId, tagId)))
+            {
+                continue;
+            }
+
+            relationships.Add(new GroupTag { GroupId = groupId, TagId = tagId });
+            if (relationships.Count < RelationshipBatchSize)
+                continue;
+
+            _db.Set<GroupTag>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+            relationships.Clear();
+            _db.ChangeTracker.Clear();
+        }
+
+        if (relationships.Count > 0)
+        {
+            _db.Set<GroupTag>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+        }
+
+        _logger.LogInformation("Imported {Count} group-tag relationships", count);
+        return count;
+    }
+
     private sealed record StashGroupImportUnit(
         IReadOnlyList<int> StashIds,
         string Name,

--- a/src/Cove.Api/Services/StashMigrationService.Performers.cs
+++ b/src/Cove.Api/Services/StashMigrationService.Performers.cs
@@ -27,15 +27,20 @@ public partial class StashMigrationService
         var rows = new List<(int Id, string Name, string? Disambiguation, string? Gender, string? Birthdate,
             string? Ethnicity, string? Country, string? EyeColor, string? HairColor, int? Height, int? Weight,
             string? Measurements, string? FakeTits, double? PenisLength, string? Circumcised,
-            string? CareerLength, string? DeathDate,
+            string? CareerLength, string? CareerStart, string? CareerEnd, string? DeathDate,
             string? Tattoos, string? Piercings, bool Favorite, int? Rating, string? Details,
             string? ImageBlob, string CreatedAt, string UpdatedAt)>();
         var hasCareerLength = await ColumnExistsAsync(conn, "performers", "career_length", ct);
+        var hasCareerStart = await ColumnExistsAsync(conn, "performers", "career_start", ct);
+        var hasCareerEnd = await ColumnExistsAsync(conn, "performers", "career_end", ct);
         await using (var cmd = conn.CreateCommand())
         {
             var careerLengthExpr = hasCareerLength ? "career_length" : "NULL";
+            var careerStartExpr = hasCareerStart ? "career_start" : "NULL";
+            var careerEndExpr = hasCareerEnd ? "career_end" : "NULL";
             cmd.CommandText = @"SELECT id, name, disambiguation, gender, birthdate, ethnicity, country, eye_color,
                 hair_color, height, weight, measurements, fake_tits, penis_length, circumcised, " + careerLengthExpr + @" AS career_length,
+                " + careerStartExpr + @" AS career_start, " + careerEndExpr + @" AS career_end,
                 death_date, tattoos, piercings, favorite, rating, details, image_blob, created_at, updated_at
                 FROM performers";
             await using var r = await cmd.ExecuteReaderAsync(ct);
@@ -45,8 +50,9 @@ public partial class StashMigrationService
                     ReadStringNull(r, 8), ReadIntNull(r, 9), ReadIntNull(r, 10), ReadStringNull(r, 11),
                     ReadStringNull(r, 12), r.IsDBNull(13) ? null : (double?)r.GetDouble(13),
                     ReadStringNull(r, 14), ReadStringNull(r, 15), ReadStringNull(r, 16),
-                    ReadStringNull(r, 17), ReadStringNull(r, 18), ReadBool(r, 19), ReadIntNull(r, 20),
-                    ReadStringNull(r, 21), ReadStringNull(r, 22), r.GetString(23), r.GetString(24)));
+                    ReadStringNull(r, 17), ReadStringNull(r, 18), ReadStringNull(r, 19), ReadStringNull(r, 20),
+                    ReadBool(r, 21), ReadIntNull(r, 22), ReadStringNull(r, 23), ReadStringNull(r, 24),
+                    r.GetString(25), r.GetString(26)));
         }
         var urls = await ReadUrlsAsync(conn, "performer_urls", "performer_id", ct);
         var aliases = await ReadAliasesAsync(conn, "performer_aliases", "performer_id", ct);
@@ -125,7 +131,9 @@ public partial class StashMigrationService
             var performerRemoteIds = performerStashIds.GetValueOrDefault(row.Id, [])
                 .DistinctBy(s => (s.Ep, s.Rid))
                 .ToList();
-            var (careerStart, careerEnd) = ParseCareerLength(row.CareerLength);
+            var (legacyCareerStart, legacyCareerEnd) = ParseCareerLength(row.CareerLength);
+            var careerStart = ParseDate(row.CareerStart) ?? legacyCareerStart;
+            var careerEnd = ParseDate(row.CareerEnd) ?? legacyCareerEnd;
             var imageBlobId = GetBlobId(blobMap, row.ImageBlob);
             if (imageBlobId is null && string.IsNullOrWhiteSpace(row.ImageBlob))
             {

--- a/src/Cove.Api/Services/StashMigrationService.Scenes.cs
+++ b/src/Cove.Api/Services/StashMigrationService.Scenes.cs
@@ -138,6 +138,20 @@ public partial class StashMigrationService
             }
         }
 
+        var captions = new Dictionary<int, List<(string LanguageCode, string Filename, string CaptionType)>>();
+        if (await TableExistsAsync(conn, "video_captions", ct))
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT file_id, language_code, filename, caption_type FROM video_captions";
+            await using var r = await cmd.ExecuteReaderAsync(ct);
+            while (await r.ReadAsync(ct))
+            {
+                var fileId = r.GetInt32(0);
+                if (!captions.TryGetValue(fileId, out var list)) captions[fileId] = list = [];
+                list.Add((r.GetString(1), r.GetString(2), r.GetString(3)));
+            }
+        }
+
         var count = 0;
         var skippedFailedScenes = 0;
         var idMap = new Dictionary<int, int>();
@@ -337,6 +351,7 @@ public partial class StashMigrationService
             _db.ChangeTracker.Clear();
             ReportPhase(progress, startProgress, endProgress, count, sceneRows.Count, $"Importing scenes ({count}/{sceneRows.Count})");
         }
+        await ImportVideoCaptionsAsync(captions, fileData, folderIdMap, ct);
         await AddImportedOverallRatingsAsync(
             sceneRows.Select(row => new ImportedRatingSeed(row.Id, row.Rating)),
             idMap,
@@ -384,6 +399,102 @@ public partial class StashMigrationService
         }
 
         return (count, idMap, generatedMap);
+    }
+
+    private async Task<int> ImportVideoCaptionsAsync(
+        IReadOnlyDictionary<int, List<(string LanguageCode, string Filename, string CaptionType)>> captionsByStashFileId,
+        IReadOnlyDictionary<int, (string Basename, int FolderId, long Size, DateTime ModTime, DateTime CreatedAt)> fileData,
+        IReadOnlyDictionary<int, int> folderIdMap,
+        CancellationToken ct)
+    {
+        if (captionsByStashFileId.Count == 0)
+            return 0;
+
+        var stashFileIdsByTargetKey = new Dictionary<string, List<int>>(StringComparer.Ordinal);
+        var parentFolderIds = new HashSet<int>();
+        var basenames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var stashFileId in captionsByStashFileId.Keys)
+        {
+            if (!fileData.TryGetValue(stashFileId, out var file)
+                || !folderIdMap.TryGetValue(file.FolderId, out var parentFolderId))
+            {
+                continue;
+            }
+
+            var targetKey = GetImportedBaseFileKey(parentFolderId, file.Basename);
+            if (!stashFileIdsByTargetKey.TryGetValue(targetKey, out var stashFileIds))
+                stashFileIdsByTargetKey[targetKey] = stashFileIds = [];
+            stashFileIds.Add(stashFileId);
+            parentFolderIds.Add(parentFolderId);
+            basenames.Add(file.Basename);
+        }
+
+        if (stashFileIdsByTargetKey.Count == 0)
+            return 0;
+
+        var parentFolderIdValues = parentFolderIds.ToArray();
+        var basenameValues = basenames.ToArray();
+        var targetFiles = await _db.Set<VideoFile>()
+            .AsNoTracking()
+            .Where(file => parentFolderIdValues.Contains(file.ParentFolderId) && basenameValues.Contains(file.Basename))
+            .Select(file => new { file.Id, file.ParentFolderId, file.Basename })
+            .ToListAsync(ct);
+        var targetFileIdByKey = targetFiles
+            .GroupBy(file => GetImportedBaseFileKey(file.ParentFolderId, file.Basename), StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.OrderBy(file => file.Id).First().Id, StringComparer.Ordinal);
+
+        var targetFileIds = targetFileIdByKey.Values.Distinct().ToList();
+        var existingCaptionKeys = (await _db.VideoCaptions
+                .AsNoTracking()
+                .Where(caption => targetFileIds.Contains(caption.FileId))
+                .Select(caption => new { caption.FileId, caption.LanguageCode, caption.CaptionType })
+                .ToListAsync(ct))
+            .Select(caption => (caption.FileId, caption.LanguageCode, caption.CaptionType))
+            .ToHashSet();
+
+        var imported = 0;
+        foreach (var (targetKey, stashFileIds) in stashFileIdsByTargetKey)
+        {
+            if (!targetFileIdByKey.TryGetValue(targetKey, out var targetFileId))
+                continue;
+
+            var sourceCaptions = stashFileIds
+                .SelectMany(stashFileId => captionsByStashFileId.GetValueOrDefault(stashFileId, []))
+                .DistinctBy(caption => (caption.LanguageCode, caption.CaptionType));
+            foreach (var caption in sourceCaptions)
+            {
+                if (!existingCaptionKeys.Add((targetFileId, caption.LanguageCode, caption.CaptionType)))
+                    continue;
+
+                _db.VideoCaptions.Add(new VideoCaption
+                {
+                    FileId = targetFileId,
+                    LanguageCode = caption.LanguageCode,
+                    Filename = caption.Filename,
+                    CaptionType = caption.CaptionType,
+                });
+                imported++;
+
+                if (imported % 500 == 0)
+                {
+                    await _db.SaveChangesAsync(ct);
+                    _db.ChangeTracker.Clear();
+                }
+            }
+        }
+
+        if (imported % 500 != 0)
+        {
+            await _db.SaveChangesAsync(ct);
+            _db.ChangeTracker.Clear();
+        }
+
+        _logger.LogInformation(
+            "Imported {CaptionCount} video captions for {MatchedFileCount}/{SourceFileCount} Stash files",
+            imported,
+            targetFileIdByKey.Keys.Count(stashFileIdsByTargetKey.ContainsKey),
+            captionsByStashFileId.Count);
+        return imported;
     }
 
     private async Task<int> ImportSceneMarkerSegmentsAsync(

--- a/src/Cove.Api/Services/StashMigrationService.Studios.cs
+++ b/src/Cove.Api/Services/StashMigrationService.Studios.cs
@@ -124,4 +124,54 @@ public partial class StashMigrationService
         _logger.LogInformation("Imported {Count} studios in {Elapsed}", idMap.Count, stopwatch.Elapsed);
         return idMap;
     }
+
+    private async Task<int> ImportStudioTagRelationshipsAsync(
+        SqliteConnection conn,
+        IReadOnlyDictionary<int, int> studioIdMap,
+        IReadOnlyDictionary<int, int> tagIdMap,
+        CancellationToken ct)
+    {
+        if (!await TableExistsAsync(conn, "studios_tags", ct))
+        {
+            _logger.LogInformation("No studios_tags table found, skipping studio-tag relationships");
+            return 0;
+        }
+
+        const int RelationshipBatchSize = 5000;
+        var relationships = new List<StudioTag>(RelationshipBatchSize);
+        var mappedRelationships = new HashSet<(int StudioId, int TagId)>();
+        var count = 0;
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT studio_id, tag_id FROM studios_tags";
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            if (!studioIdMap.TryGetValue(reader.GetInt32(0), out var studioId)
+                || !tagIdMap.TryGetValue(reader.GetInt32(1), out var tagId)
+                || !mappedRelationships.Add((studioId, tagId)))
+            {
+                continue;
+            }
+
+            relationships.Add(new StudioTag { StudioId = studioId, TagId = tagId });
+            if (relationships.Count < RelationshipBatchSize)
+                continue;
+
+            _db.Set<StudioTag>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+            relationships.Clear();
+            _db.ChangeTracker.Clear();
+        }
+
+        if (relationships.Count > 0)
+        {
+            _db.Set<StudioTag>().AddRange(relationships);
+            await _db.SaveChangesAsync(ct);
+            count += relationships.Count;
+        }
+
+        _logger.LogInformation("Imported {Count} studio-tag relationships", count);
+        return count;
+    }
 }

--- a/src/Cove.Api/Services/StashMigrationService.cs
+++ b/src/Cove.Api/Services/StashMigrationService.cs
@@ -450,6 +450,12 @@ public partial class StashMigrationService
                 () => ImportTagsAsync(conn, blobMap, progress, TagsStart, TagsEnd, ct));
             _db.ChangeTracker.Clear();
 
+            await RunBulkInsertPhaseAsync(
+                "studio-tag relationships",
+                sw,
+                () => ImportStudioTagRelationshipsAsync(conn, studioIdMap, tagIdMap, ct));
+            _db.ChangeTracker.Clear();
+
             var performerIdMap = await RunBulkInsertPhaseAsync(
                 "performers",
                 sw,

--- a/src/Cove.Api/Services/StashMigrationService.cs
+++ b/src/Cove.Api/Services/StashMigrationService.cs
@@ -468,6 +468,12 @@ public partial class StashMigrationService
                 () => ImportGroupsAsync(conn, blobMap, studioIdMap, progress, GroupsStart, GroupsEnd, ct));
             _db.ChangeTracker.Clear();
 
+            await RunBulkInsertPhaseAsync(
+                "group-tag relationships",
+                sw,
+                () => ImportGroupTagRelationshipsAsync(conn, groupIdMap, tagIdMap, ct));
+            _db.ChangeTracker.Clear();
+
             var (sceneCount, sceneIdMap, sceneGeneratedMap) = await RunBulkInsertPhaseAsync(
                 "scenes",
                 sw,

--- a/src/Cove.Api/Services/StashMigrationService.cs
+++ b/src/Cove.Api/Services/StashMigrationService.cs
@@ -474,6 +474,12 @@ public partial class StashMigrationService
                 () => ImportGroupTagRelationshipsAsync(conn, groupIdMap, tagIdMap, ct));
             _db.ChangeTracker.Clear();
 
+            await RunBulkInsertPhaseAsync(
+                "group relations",
+                sw,
+                () => ImportGroupRelationsAsync(conn, groupIdMap, ct));
+            _db.ChangeTracker.Clear();
+
             var (sceneCount, sceneIdMap, sceneGeneratedMap) = await RunBulkInsertPhaseAsync(
                 "scenes",
                 sw,

--- a/src/Cove.Api/Services/StashMigrationService.cs
+++ b/src/Cove.Api/Services/StashMigrationService.cs
@@ -480,10 +480,16 @@ public partial class StashMigrationService
                 () => ImportImagesAsync(conn, folderIdMap, studioIdMap, tagIdMap, performerIdMap, progress, ImagesStart, ImagesEnd, ct));
             _db.ChangeTracker.Clear();
 
-            var (galleryCount, galleryFileIdMap) = await RunBulkInsertPhaseAsync(
+            var (galleryCount, galleryFileIdMap, galleryIdMap) = await RunBulkInsertPhaseAsync(
                 "galleries",
                 sw,
                 () => ImportGalleriesAsync(conn, folderIdMap, studioIdMap, tagIdMap, performerIdMap, imageIdMap, progress, GalleriesStart, GalleriesEnd, ct));
+            _db.ChangeTracker.Clear();
+
+            await RunBulkInsertPhaseAsync(
+                "video-gallery relationships",
+                sw,
+                () => ImportVideoGalleryRelationshipsAsync(conn, sceneIdMap, galleryIdMap, ct));
             _db.ChangeTracker.Clear();
 
             await RunMigrationPhaseAsync(

--- a/src/Cove.Tests/StashMigrationMetadataTests.cs
+++ b/src/Cove.Tests/StashMigrationMetadataTests.cs
@@ -1043,7 +1043,7 @@ INSERT INTO galleries_images (gallery_id, image_id, cover) VALUES (10, 20, 1), (
     }
 
     [Fact]
-    public async Task ImportAsync_ImportsSceneGalleryRelationships()
+    public async Task ImportAsync_ImportsRelationshipsThatRequireDeferredIdMaps()
     {
         await using var context = CreateContext();
         var dbPath = await CreateSqliteDatabaseAsync(@"
@@ -1077,6 +1077,7 @@ CREATE TABLE tags (
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
+CREATE TABLE studios_tags (studio_id INTEGER NOT NULL, tag_id INTEGER NOT NULL);
 CREATE TABLE performers (
     id INTEGER PRIMARY KEY,
     name TEXT NOT NULL,
@@ -1168,6 +1169,15 @@ CREATE TABLE galleries (
     photographer TEXT
 );
 CREATE TABLE scenes_galleries (scene_id INTEGER NOT NULL, gallery_id INTEGER NOT NULL);
+INSERT INTO studios (id, name, favorite, created_at, updated_at)
+VALUES (30, 'Imported Studio', 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
+INSERT INTO tags (id, name, favorite, created_at, updated_at)
+VALUES (40, 'Imported Tag', 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
+INSERT INTO studios_tags (studio_id, tag_id) VALUES
+    (30, 40),
+    (30, 40),
+    (999, 40),
+    (30, 999);
 INSERT INTO scenes (id, title, organized, resume_time, play_duration, created_at, updated_at)
 VALUES (10, 'Imported Scene', 0, 0, 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
 INSERT INTO galleries (id, title, organized, created_at, updated_at)
@@ -1193,6 +1203,11 @@ INSERT INTO scenes_galleries (scene_id, gallery_id) VALUES
             var relationship = await context.Set<VideoGallery>().SingleAsync();
             Assert.Equal(video.Id, relationship.VideoId);
             Assert.Equal(gallery.Id, relationship.GalleryId);
+            var studio = await context.Studios.SingleAsync();
+            var tag = await context.Tags.SingleAsync();
+            var studioTag = await context.Set<StudioTag>().SingleAsync();
+            Assert.Equal(studio.Id, studioTag.StudioId);
+            Assert.Equal(tag.Id, studioTag.TagId);
         }
         finally
         {

--- a/src/Cove.Tests/StashMigrationMetadataTests.cs
+++ b/src/Cove.Tests/StashMigrationMetadataTests.cs
@@ -1114,9 +1114,12 @@ CREATE TABLE groups (
     rating INTEGER,
     studio_id INTEGER,
     director TEXT,
-    description TEXT
+    description TEXT,
+    front_image_blob TEXT,
+    back_image_blob TEXT
 );
 CREATE TABLE groups_tags (group_id INTEGER NOT NULL, tag_id INTEGER NOT NULL);
+CREATE TABLE groups_relations (containing_id INTEGER NOT NULL, sub_id INTEGER NOT NULL, order_index INTEGER NOT NULL, description TEXT);
 CREATE TABLE scenes (
     id INTEGER PRIMARY KEY,
     title TEXT,
@@ -1179,14 +1182,24 @@ INSERT INTO studios_tags (studio_id, tag_id) VALUES
     (30, 40),
     (999, 40),
     (30, 999);
-INSERT INTO groups (id, name) VALUES (50, 'Imported Group');
+INSERT INTO groups (id, name, front_image_blob) VALUES
+    (50, 'Containing Group', NULL),
+    (51, 'Sub Group', NULL),
+    (52, 'Containing Group', 'cover-only-group');
 INSERT INTO groups_tags (group_id, tag_id) VALUES
     (50, 40),
     (50, 40),
     (999, 40),
     (50, 999);
+INSERT INTO groups_relations (containing_id, sub_id, order_index, description) VALUES
+    (50, 51, 3, 'Imported relation'),
+    (52, 51, 7, 'Collapsed duplicate relation'),
+    (50, 52, 8, 'Collapsed self relation'),
+    (999, 51, 4, 'Missing containing group'),
+    (50, 999, 5, 'Missing subgroup');
 INSERT INTO scenes (id, title, organized, resume_time, play_duration, created_at, updated_at)
 VALUES (10, 'Imported Scene', 0, 0, 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
+INSERT INTO groups_scenes (group_id, scene_id, scene_index) VALUES (50, 10, 1);
 INSERT INTO galleries (id, title, organized, created_at, updated_at)
 VALUES (20, 'Imported Gallery', 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
 INSERT INTO scenes_galleries (scene_id, gallery_id) VALUES
@@ -1215,10 +1228,16 @@ INSERT INTO scenes_galleries (scene_id, gallery_id) VALUES
             var studioTag = await context.Set<StudioTag>().SingleAsync();
             Assert.Equal(studio.Id, studioTag.StudioId);
             Assert.Equal(tag.Id, studioTag.TagId);
-            var group = await context.Groups.SingleAsync();
+            var group = await context.Groups.SingleAsync(item => item.Name == "Containing Group");
             var groupTag = await context.Set<GroupTag>().SingleAsync();
             Assert.Equal(group.Id, groupTag.GroupId);
             Assert.Equal(tag.Id, groupTag.TagId);
+            var subGroup = await context.Groups.SingleAsync(item => item.Name == "Sub Group");
+            var groupRelation = await context.Set<GroupRelation>().SingleAsync();
+            Assert.Equal(group.Id, groupRelation.ContainingGroupId);
+            Assert.Equal(subGroup.Id, groupRelation.SubGroupId);
+            Assert.Equal(3, groupRelation.OrderIndex);
+            Assert.Equal("Imported relation", groupRelation.Description);
         }
         finally
         {

--- a/src/Cove.Tests/StashMigrationMetadataTests.cs
+++ b/src/Cove.Tests/StashMigrationMetadataTests.cs
@@ -788,6 +788,12 @@ CREATE TABLE video_files (
   interactive INTEGER NOT NULL,
   interactive_speed INTEGER
 );
+CREATE TABLE video_captions (
+  file_id INTEGER NOT NULL,
+  language_code TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  caption_type TEXT NOT NULL
+);
 CREATE TABLE files_fingerprints (file_id INTEGER NOT NULL, type TEXT NOT NULL, fingerprint TEXT NOT NULL);
 INSERT INTO scenes (id, title, organized, resume_time, play_duration, created_at, updated_at, last_played_at)
 VALUES (1, 'Imported Scene', 0, 15, 45, '2024-01-01T00:00:00Z', '2024-02-01T00:00:00Z', '2024-03-01T00:00:00Z');
@@ -797,6 +803,9 @@ INSERT INTO files (id, basename, parent_folder_id, size, mod_time, created_at)
 VALUES (10, 'clip.mp4', 99, 2048, '2024-04-01T00:00:00Z', '2024-01-05T00:00:00Z');
 INSERT INTO video_files (file_id, duration, video_codec, format, audio_codec, width, height, frame_rate, bit_rate, interactive, interactive_speed)
 VALUES (10, 120, 'H264', 'mp4', 'AAC', 1920, 1080, 30, 2000000, 0, NULL);
+INSERT INTO video_captions (file_id, language_code, filename, caption_type) VALUES
+  (10, 'en', 'clip.en.vtt', 'vtt'),
+  (10, 'es', 'clip.es.srt', 'srt');
 ");
 
         var service = CreateService(context);
@@ -815,8 +824,13 @@ VALUES (10, 120, 'H264', 'mp4', 'AAC', 1920, 1080, 30, 2000000, 0, NULL);
             1d,
             CancellationToken.None);
 
-        var scene = await context.Videos.Include(s => s.Files).SingleAsync();
+        var scene = await context.Videos.Include(s => s.Files).ThenInclude(file => file.Captions).SingleAsync();
         var file = Assert.Single(scene.Files);
+        Assert.Equal(
+            [("en", "clip.en.vtt", "vtt"), ("es", "clip.es.srt", "srt")],
+            file.Captions.OrderBy(caption => caption.LanguageCode)
+                .Select(caption => (caption.LanguageCode, caption.Filename, caption.CaptionType))
+                .ToArray());
         var affinity = await context.UserEntityAffinities.SingleAsync(item => item.HostType == AffinityHostType.Video && item.HostId == scene.Id);
         Assert.Equal(new DateTime(2024, 3, 1, 0, 0, 0, DateTimeKind.Utc), affinity.LastConsumedAt);
         Assert.Equal(1, affinity.ViewCount);
@@ -826,6 +840,93 @@ VALUES (10, 120, 'H264', 'mp4', 'AAC', 1920, 1080, 30, 2000000, 0, NULL);
         Assert.Equal(new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc), scene.UpdatedAt);
         Assert.Equal(new DateTime(2024, 1, 5, 0, 0, 0, DateTimeKind.Utc), file.CreatedAt);
         Assert.Equal(new DateTime(2024, 4, 1, 0, 0, 0, DateTimeKind.Utc), file.UpdatedAt);
+    }
+
+    [Fact]
+    public async Task ImportScenesAsync_ImportsCaptionsForMatchingPersistedVideoFiles()
+    {
+        await using var context = CreateContext();
+        var folder = new Folder { Path = @"C:\library", ModTime = new DateTime(2024, 1, 4, 0, 0, 0, DateTimeKind.Utc) };
+        var existingVideo = new Scene
+        {
+            Title = "Existing video",
+            Files =
+            [
+                new VideoFile
+                {
+                    Basename = "sample-captioned-video.mp4",
+                    ParentFolder = folder,
+                    Format = "mp4",
+                    VideoCodec = "H264",
+                    AudioCodec = "AAC",
+                },
+            ],
+        };
+        context.Videos.Add(existingVideo);
+        await context.SaveChangesAsync();
+
+        await using var stash = new SqliteConnection("Data Source=:memory:");
+        await stash.OpenAsync();
+        await ExecuteSqlAsync(stash, @"
+CREATE TABLE scenes (
+  id INTEGER PRIMARY KEY, title TEXT, details TEXT, date TEXT, rating INTEGER, studio_id INTEGER,
+  organized INTEGER NOT NULL, code TEXT, director TEXT, resume_time REAL NOT NULL,
+  play_duration REAL NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+CREATE TABLE scenes_tags (scene_id INTEGER NOT NULL, tag_id INTEGER NOT NULL);
+CREATE TABLE performers_scenes (scene_id INTEGER NOT NULL, performer_id INTEGER NOT NULL);
+CREATE TABLE groups_scenes (scene_id INTEGER NOT NULL, group_id INTEGER NOT NULL, scene_index INTEGER);
+CREATE TABLE scene_urls (scene_id INTEGER NOT NULL, url TEXT NOT NULL, position INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE scenes_o_dates (scene_id INTEGER NOT NULL, o_date TEXT NOT NULL);
+CREATE TABLE scenes_view_dates (scene_id INTEGER NOT NULL, view_date TEXT NOT NULL);
+CREATE TABLE scenes_files (scene_id INTEGER NOT NULL, file_id INTEGER NOT NULL, [primary] INTEGER NOT NULL);
+CREATE TABLE files (
+  id INTEGER PRIMARY KEY, basename TEXT NOT NULL, parent_folder_id INTEGER NOT NULL,
+  size INTEGER NOT NULL, mod_time TEXT NOT NULL, created_at TEXT NOT NULL
+);
+CREATE TABLE video_files (
+  file_id INTEGER PRIMARY KEY, duration REAL NOT NULL, video_codec TEXT NOT NULL,
+  format TEXT NOT NULL, audio_codec TEXT NOT NULL, width INTEGER NOT NULL, height INTEGER NOT NULL,
+  frame_rate REAL NOT NULL, bit_rate INTEGER NOT NULL, interactive INTEGER NOT NULL,
+  interactive_speed INTEGER
+);
+CREATE TABLE video_captions (
+  file_id INTEGER NOT NULL, language_code TEXT NOT NULL, filename TEXT NOT NULL,
+  caption_type TEXT NOT NULL
+);
+CREATE TABLE files_fingerprints (file_id INTEGER NOT NULL, type TEXT NOT NULL, fingerprint TEXT NOT NULL);
+INSERT INTO scenes (id, title, organized, resume_time, play_duration, created_at, updated_at)
+VALUES (1, 'Captioned Video', 0, 0, 0, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z');
+INSERT INTO scenes_files (scene_id, file_id, [primary]) VALUES (1, 10, 1);
+INSERT INTO files (id, basename, parent_folder_id, size, mod_time, created_at)
+VALUES (10, 'sample-captioned-video.mp4', 99, 2048, '2024-04-01T00:00:00Z', '2024-01-05T00:00:00Z');
+INSERT INTO video_files (file_id, duration, video_codec, format, audio_codec, width, height, frame_rate, bit_rate, interactive, interactive_speed)
+VALUES (10, 120, 'H264', 'mp4', 'AAC', 1920, 1080, 30, 2000000, 0, NULL);
+INSERT INTO video_captions (file_id, language_code, filename, caption_type)
+VALUES (10, '00', 'sample-captioned-video.srt', 'srt');
+");
+
+        var service = CreateService(context);
+        await InvokePrivateAsync(
+            service,
+            "ImportScenesAsync",
+            stash,
+            new Dictionary<string, string>(),
+            new Dictionary<int, int> { [99] = folder.Id },
+            new Dictionary<int, int>(),
+            new Dictionary<int, int>(),
+            new Dictionary<int, int>(),
+            new Dictionary<int, int>(),
+            NullJobProgress.Instance,
+            0d,
+            1d,
+            CancellationToken.None);
+
+        var file = await context.Set<VideoFile>().Include(item => item.Captions).SingleAsync();
+        var caption = Assert.Single(file.Captions);
+        Assert.Equal("00", caption.LanguageCode);
+        Assert.Equal("sample-captioned-video.srt", caption.Filename);
+        Assert.Equal("srt", caption.CaptionType);
     }
 
         [Fact]

--- a/src/Cove.Tests/StashMigrationMetadataTests.cs
+++ b/src/Cove.Tests/StashMigrationMetadataTests.cs
@@ -921,6 +921,66 @@ VALUES (1, 50, NULL, 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
     }
 
     [Fact]
+    public async Task ImportGalleriesAsync_ImportsSelectedCoverImage()
+    {
+        await using var context = CreateContext();
+        var image = new Image { Title = "Selected Cover" };
+        var otherImage = new Image { Title = "Other Image" };
+        context.Images.AddRange(image, otherImage);
+        await context.SaveChangesAsync();
+
+        await using var stash = new SqliteConnection("Data Source=:memory:");
+        await stash.OpenAsync();
+        await ExecuteSqlAsync(stash, @"
+CREATE TABLE galleries (
+  id INTEGER PRIMARY KEY,
+  folder_id INTEGER,
+  title TEXT,
+  date TEXT,
+  details TEXT,
+  studio_id INTEGER,
+  rating INTEGER,
+  organized INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  code TEXT,
+  photographer TEXT
+);
+CREATE TABLE galleries_images (gallery_id INTEGER NOT NULL, image_id INTEGER NOT NULL, cover INTEGER NOT NULL);
+CREATE TABLE files (
+  id INTEGER PRIMARY KEY,
+  basename TEXT NOT NULL,
+  parent_folder_id INTEGER NOT NULL,
+  size INTEGER NOT NULL,
+  mod_time TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+INSERT INTO galleries (id, title, organized, created_at, updated_at)
+VALUES (10, 'Imported Gallery', 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
+INSERT INTO galleries_images (gallery_id, image_id, cover) VALUES (10, 20, 1), (10, 21, 0);
+");
+
+        var service = CreateService(context);
+        await InvokePrivateAsync(
+            service,
+            "ImportGalleriesAsync",
+            stash,
+            new Dictionary<int, int>(),
+            new Dictionary<int, int>(),
+            new Dictionary<int, int>(),
+            new Dictionary<int, int>(),
+            new Dictionary<int, int> { [20] = image.Id, [21] = otherImage.Id },
+            NullJobProgress.Instance,
+            0d,
+            1d,
+            CancellationToken.None);
+
+        var gallery = await context.Galleries.Include(item => item.ImageGalleries).SingleAsync();
+        Assert.Equal(image.Id, gallery.CoverImageId);
+        Assert.Equal([image.Id, otherImage.Id], gallery.ImageGalleries.Select(link => link.ImageId).Order().ToArray());
+    }
+
+    [Fact]
     public async Task ImportAsync_ImportsSceneGalleryRelationships()
     {
         await using var context = CreateContext();

--- a/src/Cove.Tests/StashMigrationMetadataTests.cs
+++ b/src/Cove.Tests/StashMigrationMetadataTests.cs
@@ -914,10 +914,168 @@ VALUES (1, 50, NULL, 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
             1d,
             CancellationToken.None);
 
-                var galleryImport = Assert.IsType<(int Count, Dictionary<int, int> GalleryFileIdMap)>(result);
+                var galleryImport = Assert.IsType<(int Count, Dictionary<int, int> GalleryFileIdMap, Dictionary<int, int> GalleryIdMap)>(result);
                 Assert.Equal(1, galleryImport.Count);
         var gallery = await context.Galleries.SingleAsync();
         Assert.Equal("Summer Set", gallery.Title);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ImportsSceneGalleryRelationships()
+    {
+        await using var context = CreateContext();
+        var dbPath = await CreateSqliteDatabaseAsync(@"
+CREATE TABLE blobs (checksum TEXT NOT NULL, blob BLOB);
+CREATE TABLE folders (
+    id INTEGER PRIMARY KEY,
+    path TEXT NOT NULL,
+    parent_folder_id INTEGER,
+    zip_file_id INTEGER,
+    mod_time TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+CREATE TABLE studios (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    parent_id INTEGER,
+    details TEXT,
+    rating INTEGER,
+    favorite INTEGER NOT NULL,
+    image_blob TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE TABLE tags (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    sort_name TEXT,
+    description TEXT,
+    favorite INTEGER NOT NULL,
+    image_blob TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE TABLE performers (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    disambiguation TEXT,
+    gender TEXT,
+    birthdate TEXT,
+    ethnicity TEXT,
+    country TEXT,
+    eye_color TEXT,
+    hair_color TEXT,
+    height INTEGER,
+    weight INTEGER,
+    measurements TEXT,
+    fake_tits TEXT,
+    penis_length REAL,
+    circumcised TEXT,
+    career_length TEXT,
+    death_date TEXT,
+    tattoos TEXT,
+    piercings TEXT,
+    favorite INTEGER NOT NULL,
+    rating INTEGER,
+    details TEXT,
+    image_blob TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE TABLE groups (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    aliases TEXT,
+    duration INTEGER,
+    date TEXT,
+    rating INTEGER,
+    studio_id INTEGER,
+    director TEXT,
+    description TEXT
+);
+CREATE TABLE scenes (
+    id INTEGER PRIMARY KEY,
+    title TEXT,
+    details TEXT,
+    date TEXT,
+    rating INTEGER,
+    studio_id INTEGER,
+    organized INTEGER NOT NULL,
+    code TEXT,
+    director TEXT,
+    resume_time REAL NOT NULL,
+    play_duration REAL NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+CREATE TABLE groups_scenes (scene_id INTEGER NOT NULL, group_id INTEGER NOT NULL, scene_index INTEGER);
+CREATE TABLE scenes_files (scene_id INTEGER NOT NULL, file_id INTEGER NOT NULL, [primary] INTEGER NOT NULL);
+CREATE TABLE files (
+    id INTEGER PRIMARY KEY,
+    basename TEXT NOT NULL,
+    parent_folder_id INTEGER NOT NULL,
+    zip_file_id INTEGER,
+    size INTEGER NOT NULL,
+    mod_time TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+CREATE TABLE video_files (
+    file_id INTEGER PRIMARY KEY,
+    duration REAL NOT NULL,
+    video_codec TEXT NOT NULL,
+    format TEXT NOT NULL,
+    audio_codec TEXT NOT NULL,
+    width INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    frame_rate REAL NOT NULL,
+    bit_rate INTEGER NOT NULL
+);
+CREATE TABLE files_fingerprints (file_id INTEGER NOT NULL, type TEXT NOT NULL, fingerprint);
+CREATE TABLE galleries (
+    id INTEGER PRIMARY KEY,
+    folder_id INTEGER,
+    title TEXT,
+    date TEXT,
+    details TEXT,
+    studio_id INTEGER,
+    rating INTEGER,
+    organized INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    code TEXT,
+    photographer TEXT
+);
+CREATE TABLE scenes_galleries (scene_id INTEGER NOT NULL, gallery_id INTEGER NOT NULL);
+INSERT INTO scenes (id, title, organized, resume_time, play_duration, created_at, updated_at)
+VALUES (10, 'Imported Scene', 0, 0, 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
+INSERT INTO galleries (id, title, organized, created_at, updated_at)
+VALUES (20, 'Imported Gallery', 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
+INSERT INTO scenes_galleries (scene_id, gallery_id) VALUES
+    (10, 20),
+    (10, 20),
+    (999, 20),
+    (10, 999);
+", "cove-scene-gallery-migration");
+
+        try
+        {
+            var service = CreateService(context);
+            var result = await service.ImportAsync(
+                dbPath,
+                new StashImportOptions(CoveGeneratedPath: null, MigrateGeneratedContent: false));
+
+            Assert.Equal(1, result.Videos);
+            Assert.Equal(1, result.Galleries);
+            var video = await context.Videos.SingleAsync();
+            var gallery = await context.Galleries.SingleAsync();
+            var relationship = await context.Set<VideoGallery>().SingleAsync();
+            Assert.Equal(video.Id, relationship.VideoId);
+            Assert.Equal(gallery.Id, relationship.GalleryId);
+        }
+        finally
+        {
+            TryDeleteFile(dbPath);
+        }
     }
 
     [Fact]
@@ -1292,7 +1450,7 @@ INSERT INTO galleries_files (gallery_id, file_id, [primary]) VALUES (200, 10, 1)
                         1d,
                         CancellationToken.None));
 
-                var galleryImport = Assert.IsType<(int Count, Dictionary<int, int> GalleryFileIdMap)>(await InvokePrivateAsync(
+                var galleryImport = Assert.IsType<(int Count, Dictionary<int, int> GalleryFileIdMap, Dictionary<int, int> GalleryIdMap)>(await InvokePrivateAsync(
                         service,
                         "ImportGalleriesAsync",
                         stash,

--- a/src/Cove.Tests/StashMigrationMetadataTests.cs
+++ b/src/Cove.Tests/StashMigrationMetadataTests.cs
@@ -1116,6 +1116,7 @@ CREATE TABLE groups (
     director TEXT,
     description TEXT
 );
+CREATE TABLE groups_tags (group_id INTEGER NOT NULL, tag_id INTEGER NOT NULL);
 CREATE TABLE scenes (
     id INTEGER PRIMARY KEY,
     title TEXT,
@@ -1178,6 +1179,12 @@ INSERT INTO studios_tags (studio_id, tag_id) VALUES
     (30, 40),
     (999, 40),
     (30, 999);
+INSERT INTO groups (id, name) VALUES (50, 'Imported Group');
+INSERT INTO groups_tags (group_id, tag_id) VALUES
+    (50, 40),
+    (50, 40),
+    (999, 40),
+    (50, 999);
 INSERT INTO scenes (id, title, organized, resume_time, play_duration, created_at, updated_at)
 VALUES (10, 'Imported Scene', 0, 0, 0, '2024-01-01T00:00:00Z', '2024-01-02T00:00:00Z');
 INSERT INTO galleries (id, title, organized, created_at, updated_at)
@@ -1208,6 +1215,10 @@ INSERT INTO scenes_galleries (scene_id, gallery_id) VALUES
             var studioTag = await context.Set<StudioTag>().SingleAsync();
             Assert.Equal(studio.Id, studioTag.StudioId);
             Assert.Equal(tag.Id, studioTag.TagId);
+            var group = await context.Groups.SingleAsync();
+            var groupTag = await context.Set<GroupTag>().SingleAsync();
+            Assert.Equal(group.Id, groupTag.GroupId);
+            Assert.Equal(tag.Id, groupTag.TagId);
         }
         finally
         {

--- a/src/Cove.Tests/StashMigrationMetadataTests.cs
+++ b/src/Cove.Tests/StashMigrationMetadataTests.cs
@@ -157,6 +157,68 @@ INSERT INTO performers (id, name, favorite, ignore_auto_tag) VALUES (1, 'Legacy 
         Assert.Null(performer.CareerEnd);
     }
 
+    [Fact]
+    public async Task ImportPerformersAsync_ImportsCurrentCareerDateColumns()
+    {
+        await using var context = CreateContext();
+
+        await using var stash = new SqliteConnection("Data Source=:memory:");
+        await stash.OpenAsync();
+        await ExecuteSqlAsync(stash, @"
+CREATE TABLE performers (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL,
+  disambiguation TEXT,
+  gender TEXT,
+  birthdate TEXT,
+  ethnicity TEXT,
+  country TEXT,
+  eye_color TEXT,
+  hair_color TEXT,
+  height INTEGER,
+  weight INTEGER,
+  measurements TEXT,
+  fake_tits TEXT,
+  penis_length REAL,
+  circumcised TEXT,
+  career_length TEXT,
+  career_start TEXT,
+  career_end TEXT,
+  death_date TEXT,
+  tattoos TEXT,
+  piercings TEXT,
+  favorite INTEGER NOT NULL,
+  rating INTEGER,
+  details TEXT,
+  ignore_auto_tag INTEGER NOT NULL,
+  image_blob TEXT,
+  created_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00Z',
+  updated_at TEXT NOT NULL DEFAULT '2024-01-01T00:00:00Z'
+);
+INSERT INTO performers (id, name, career_length, career_start, career_end, favorite, ignore_auto_tag) VALUES
+  (1, 'Current Performer', '1999-2001', '2008-01-01', '2020-01-01', 0, 0),
+  (2, 'Partial Current Performer', '1995-2005', NULL, '2010-01-01', 0, 0);
+");
+
+        var service = CreateService(context);
+        await InvokePrivateAsync(
+            service,
+            "ImportPerformersAsync",
+            stash,
+            new Dictionary<string, string>(),
+            new Dictionary<int, int>(),
+            NullJobProgress.Instance,
+            0d,
+            1d,
+            CancellationToken.None);
+
+        var performers = await context.Performers.ToDictionaryAsync(performer => performer.Name);
+        Assert.Equal(new DateOnly(2008, 1, 1), performers["Current Performer"].CareerStart);
+        Assert.Equal(new DateOnly(2020, 1, 1), performers["Current Performer"].CareerEnd);
+        Assert.Equal(new DateOnly(1995, 1, 1), performers["Partial Current Performer"].CareerStart);
+        Assert.Equal(new DateOnly(2010, 1, 1), performers["Partial Current Performer"].CareerEnd);
+    }
+
         [Fact]
         public async Task ImportPerformersAsync_ImportsMultiplePerformersWithUrls()
         {


### PR DESCRIPTION
## Summary

Preserve Stash scene-gallery, studio-tag, group-tag, and group-to-group relationships, selected gallery cover images, performer career dates, and video-file captions during migration. Translate relationship endpoints and cover images through the ID maps produced by the same import. Read current Stash `career_start`/`career_end` columns while retaining compatibility with legacy `career_length` and schemas without career fields.

## Linked issue

Closes #64 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Docs
- [ ] Other:

## AI usage

- [ ] No AI was used for this PR.
- [x] AI was used for this PR.
  - **Model(s):** GPT-5 Codex
  - **Where / how:** Live UI reproduction, source and disposable database investigation, implementation, regression-test creation, and verification.
- [X] **A human (me) has reviewed, understands, and takes full responsibility for every change here including that the design and architecture are sound.** *(required)*

## Testing done & evidence

- Tested all affected gaps with both a negative and a positive migration.

## Checklist

- [x] I have read and followed the [Contribution Guide](../CONTRIBUTING.md).
- [x] Builds and existing tests pass.
- [x] I added or updated tests where it makes sense.
- [x] I updated docs where needed. (No user documentation change required.)
- [x] This PR is focused and does not bundle unrelated changes.